### PR TITLE
Update the version to include a git-hash.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,3 +120,10 @@ lazy val root = Project(id="commons", base=file("."))
       "org.scalatest"  %% "scalatest"     % "3.0.1"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
     )
   )
+
+lazy val shadowJar = TaskKey[Unit]("shadowJar", "Creates an assembly JAR without the trailing git hash and SNAPSHOT in the name")
+shadowJar <<= assembly map { (asm) => 
+  val regex = "-[a-z0-9]+-SNAPSHOT.jar".r
+  val jar   = regex.replaceAllIn(asm.getPath, ".jar")
+  Seq("cp", asm.getPath, jar) !!
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.url("fix-sbt-plugin-releases", url("http://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.typesafe.sbt"  % "sbt-git"       % "0.8.5")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-git"       % "0.9.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.3")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.3")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,4 @@
-version in ThisBuild := "0.2.0-SNAPSHOT"
+val gitHeadCommitSha = settingKey[String]("current git commit SHA")
+gitHeadCommitSha in ThisBuild := Process("git rev-parse --short HEAD").lines.head
+
+version in ThisBuild := s"0.2.0-${gitHeadCommitSha.value}-SNAPSHOT"


### PR DESCRIPTION
Also add a task, 'shadowJar', that creates a JAR without the trailing
<git-hash>-SNAPSHOT.jar.