### PR TITLE
Made it so that any case of t/true/y/yes will parse as true.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtil.scala
@@ -52,6 +52,9 @@ object ReflectionUtil {
 
   val SpecialEmptyOrNoneToken = ":none:"
 
+  /** Lower case version of strings that should be considered true when parsing a boolean. */
+  val StringsThatAreTrue = IndexedSeq("true", "yes", "t", "y")
+
   /** A cache of Type objects to their Class objects. */
   private val typeToClassCache = mutable.HashMap[Type, Class[_]]()
 
@@ -372,6 +375,9 @@ object ReflectionUtil {
     }
     else if (clazz == classOf[Path]) {
       PathUtil.pathTo(value)
+    }
+    else if (clazz == classOf[java.lang.Boolean]) {
+      StringsThatAreTrue.contains(value.toLowerCase)
     }
     else if (clazz == classOf[Option[_]]) {
       // unitType shouldn't be an option, since it's supposed to the type *inside* any containers

--- a/src/test/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtilTest.scala
@@ -34,6 +34,7 @@ import scala.annotation.ClassfileAnnotation
 import scala.reflect.runtime.{universe => ru}
 import scala.reflect.runtime.universe._
 import scala.reflect.ClassTag
+import scala.util.Success
 
 object ReflectionUtilTest {
   case class IntNoDefault(var v: Int)
@@ -323,6 +324,18 @@ class ReflectionUtilTest extends UnitSpec {
 
   it should "not be able to construct a non-collection if given multiple values" in {
     an[Exception] should be thrownBy ReflectionUtil.typedValueFromString(classOf[Int], classOf[Int], "1", "2", "3").get
+  }
+
+  Seq("Y", "y", "Yes", "YES", "yes", "true", "tRUE", "TRUE", "t", "T").foreach { truth =>
+      it should s"parse $truth as true for a boolean value" in {
+        ReflectionUtil.constructFromString(classOf[Boolean], classOf[Boolean], truth) shouldBe Success(true)
+      }
+  }
+
+  Seq("yup", "nope", "no", "false", "truthy", "True Dat").foreach { falsehood  =>
+      it should s"parse $falsehood as false for a boolean value" in {
+        ReflectionUtil.constructFromString(classOf[Boolean], classOf[Boolean], falsehood) shouldBe Success(false)
+      }
   }
 
   "ReflectionUtil.enumOptions" should "return the options for an enum" in {


### PR DESCRIPTION
Simple update so that more than just the single literal "true" are parsed as true for booleans.