### PR TITLE
Make Io.readLinesFromResource more friendly.

### DIFF
--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -164,12 +164,23 @@ class IoTest extends UnitSpec {
     roundtripped shouldBe lines
   }
 
+  // The expected lines from the file loaded as a resource
+  private val ResourceLines = Io.readLines(Paths.get("src/test/resources/com/fulcrumgenomics/commons/io/to-lines-from-resource-test.txt")).toList
+
   "Io.readLinesFromResource" should "read lines from a resource" in {
     val actual = Io.readLinesFromResource("/com/fulcrumgenomics/commons/io/to-lines-from-resource-test.txt").toList
-    val file = Paths.get("src/test/resources/com/fulcrumgenomics/commons/io/to-lines-from-resource-test.txt")
-    val expected = Io.toSource(file).getLines().toList
+    actual shouldBe ResourceLines
+  }
 
-    actual shouldBe expected
+  it should "work without a leading slash" in {
+    val actual = Io.readLinesFromResource("com/fulcrumgenomics/commons/io/to-lines-from-resource-test.txt").toList
+    actual shouldBe ResourceLines
+  }
+
+  it should "work with a relative path" in {
+    // This works because the resource is in the same package as this test class
+    val actual = Io.readLinesFromResource("to-lines-from-resource-test.txt").toList
+    actual shouldBe ResourceLines
   }
 
   it should "fail when the resource does not exist" in {


### PR DESCRIPTION
`getClass().getResourceAsStream()` and `getClass().getClassLoader().getResourceAsStream()` have different behaviours that can cause a lot of confusion.  Specifically:
  - the latter treats all paths as absolute but fails if you have a leading slash
  - the former treats paths as relative _unless_ they start with a slash

The result of this change is that a resource will be found if it is either:
a) A correct relative path
b) An absolute path without a slash
c) An absolute path with a slash