### PR TITLE
Make the parser faster when accessing field value as Strings.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -36,7 +36,7 @@ import scala.reflect.runtime.{universe => ru}
   */
 class Row private[util] (private val headerIndices: Map[String,Int], private val fields: Array[String], val trim: Boolean) {
   /* Internal method to pull a value out of the field array by index and trim it if requested. */
-  private def value(index: Int) = {
+  private def value(index: Int): String = {
     if (index > fields.length-1) throw new IndexOutOfBoundsException(s"Invalid column index supplied: ${index}")
     val string = fields(index)
     if (trim) string.trim else string
@@ -50,6 +50,12 @@ class Row private[util] (private val headerIndices: Map[String,Int], private val
 
   /** Fetches a value of the desired type by column name. */
   def apply[A](column: String)(implicit tag: ru.TypeTag[A]): A = apply(headerIndices(column))
+
+  /** Non-type-parameterized apply method that returns the column value as a String. */
+  def string(column: String): String = value(headerIndices(column))
+
+  /** Non-type-parameterized apply method that returns the column value as a String. */
+  def string(index: Int): String = value(index)
 
   /** Gets a value from the column with the specified index. If the value is null or empty returns None. */
   def get[A](index: Int)(implicit tag: ru.TypeTag[A]): Option[A] = {

--- a/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
@@ -148,6 +148,24 @@ class DelimitedDataParserTest extends UnitSpec {
     row3.get[Int]("c") shouldBe Some(3)
   }
 
+  it should "give the same results from apply[String] and string()" in {
+    val data = """
+      |foo,bar,splat
+      |one,uno,1
+      |two,dos ,2
+    """.stripMargin.trim.lines.filter(_.nonEmpty).toIndexedSeq
+    val parser = csv(data)
+    var rows = 0
+    parser.foreach { row =>
+      row[String]("foo")   shouldBe row.string("foo")
+      row[String]("bar")   shouldBe row.string("bar")
+      row[String]("splat") shouldBe row.string("splat")
+      rows += 1
+    }
+
+    rows shouldBe 2
+  }
+
   "DelimitedDataParser.getOrNone" should "return None if the column header does not exist" in {
     val parser = csv(Seq("a,b,c", "1,2,3"))
     val row = parser.next()


### PR DESCRIPTION
@nh13 I really like our `DelimitedDataParser` but all the reflection makes it really slow when dealing with large files (100,000s or millions of rows).  I have a tool I'm working on that is processing files of many millions of rows.  I'm accessing all the values as Strings, and switching away from calling the reflection code makes is over 10X faster overall!! 

Totally open to changing the names of the methods if you have a better suggestion.  I was hoping I could implement it as just `def apply(column: String): String`.  That does compile, but then when you try to use it you get compile failures because it's ambiguous :(