### PR TITLE
Attempting to move to cross-building 2.12 and 2.13, dropping 2.11.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,8 +83,8 @@ lazy val commonSettings = Seq(
   organizationHomepage := Some(url("http://www.fulcrumgenomics.com")),
   homepage             := Some(url("http://github.com/fulcrumgenomics/commons")),
   startYear            := Some(2015),
-  scalaVersion         := "2.12.8",
-  crossScalaVersions   := Seq("2.11.12", "2.12.8"),
+  scalaVersion         := "2.13.0",
+  crossScalaVersions   := Seq("2.12.8", "2.13.0"),
   scalacOptions        ++= Seq("-target:jvm-1.8", "-deprecation", "-unchecked"),
   scalacOptions in (Compile, doc) ++= docScalacOptions,
   scalacOptions in (Test, doc) ++= docScalacOptions,
@@ -116,6 +116,16 @@ lazy val root = Project(id="commons", base=file("."))
       "com.typesafe"   %  "config"        % "1.3.2",
       "org.scala-lang" %  "scala-reflect" % scalaVersion.value,
       //---------- Test libraries -------------------//
-      "org.scalatest"  %% "scalatest"     % "3.0.1"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
+      "org.scalatest"  %% "scalatest"     % "3.0.8"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
     )
+  )
+  .settings(
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, major)) if major >= 13 =>
+          Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0")
+        case _ =>
+          Seq()
+      }
+    }
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("fix-sbt-plugin-releases", url("http://dl.bintray.com/
 addSbtPlugin("com.typesafe.sbt"  % "sbt-git"       % "0.9.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.6")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.6")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"  % "2.2")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.1.0")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.9.0")

--- a/src/main/scala/com/fulcrumgenomics/commons/async/AsyncRunnable.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/async/AsyncRunnable.scala
@@ -134,17 +134,17 @@ trait AsyncRunnable extends Runnable {
   protected def execute(): Unit
 
   /** The method to execute if an exception occurs in the asynchronous thread.  This should not block. */
-  protected def uponException(): Unit = Unit
+  protected def uponException(): Unit = ()
 
   /** The method to execute upon successfully execution of the run method or an exception occurs.  This should not block. */
-  protected def uponFinally(): Unit = Unit
+  protected def uponFinally(): Unit = ()
 
   /** Checks to see if an exception has been raised by an asynchronous thread and if so rethrows it.  Use this method
     * before code that assumes the threads have not encountered an exception.
     */
   protected final def checkAndRaise(): Unit = {
     _throwable.getAndSet(null) match {
-      case null           => Unit
+      case null           => ()
       case thr: Throwable => throw thr
     }
   }

--- a/src/main/scala/com/fulcrumgenomics/commons/collection/BetterBufferedIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/collection/BetterBufferedIterator.scala
@@ -36,11 +36,11 @@ sealed trait HeadOption[A] {
   * A better buffered iterator that provides implementations of takeWhile and dropWhile
   * that don't discard extra values.
   */
-class BetterBufferedIterator[A](private val iterator: Iterator[A]) extends HeadOption[A] with BufferedIterator[A] {
+class BetterBufferedIterator[A](private val iter: Iterator[A]) extends HeadOption[A] with BufferedIterator[A] {
   private var buffer: Option[A] = maybeNext
 
   /** Returns a Some(A) if there is a next in the iterator else None. */
-  private def maybeNext = if (this.iterator.hasNext) Some(this.iterator.next()) else None
+  private def maybeNext = if (this.iter.hasNext) Some(this.iter.next()) else None
 
   /** Returns the next item in the iterator without consuming it. */
   override def head: A = this.buffer.get

--- a/src/main/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtil.scala
@@ -29,6 +29,7 @@ import java.nio.file.Path
 import com.fulcrumgenomics.commons.io.PathUtil
 import com.fulcrumgenomics.commons.CommonsDef._
 
+import scala.language.postfixOps
 import scala.annotation.{ClassfileAnnotation, tailrec}
 import scala.collection.mutable
 import scala.reflect._

--- a/src/main/scala/com/fulcrumgenomics/commons/reflect/ReflectiveBuilder.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/reflect/ReflectiveBuilder.scala
@@ -187,11 +187,11 @@ class ArgumentLookup[ArgType <: Argument](args: ArgType*) {
     byFieldName(arg.name)  = arg
   }
 
-  /** Returns a view over the list of argument definitions for easy filtering/querying/mapping. */
-  def view:Seq[ArgType] = this.argumentDefinitions.view
+  /** Returns an iterator over the list of argument definitions for easy filtering/querying/mapping. */
+  def iterator: Iterator[ArgType] = this.argumentDefinitions.iterator
 
   /** Returns the full set of argument definitions ordered by their indices. */
-  def ordered : Seq[ArgType] = argumentDefinitions.toList.sortBy(_.index)
+  def ordered: Seq[ArgType] = argumentDefinitions.toList.sortBy(_.index)
 
   /** Returns the ArgumentDefinition, if one exists, for the provided field name. */
   def forField(fieldName: String) : Option[ArgType] = this.byFieldName.get(fieldName)

--- a/src/main/scala/com/fulcrumgenomics/commons/util/ConfigurationLike.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/ConfigurationLike.scala
@@ -78,7 +78,7 @@ trait ConfigurationLike {
   protected def config : Config
 
   /** Method that can be overridden to receive a call each time a configuration path is requested. */
-  protected def keyRequested(path: String): Unit = Unit
+  protected def keyRequested(path: String): Unit = ()
 
   /**
     * Method to allow subclasses to override how errors are handled, e.g. by logging or throwing

--- a/src/main/scala/com/fulcrumgenomics/commons/util/NumericCounter.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/NumericCounter.scala
@@ -70,15 +70,15 @@ class NumericCounter[T](implicit numeric: Numeric[T]) extends SimpleCounter[T] {
   /** Returns the mean as a [Double], or zero if there are no counts. */
   def mean(): Double = {
     if (0 == size) return 0.0
-    this._totalMass.toDouble() / total
+    this._totalMass.toDouble / total
   }
 
   /** Returns the standard deviation as a [Double], or zero if there are no counts.  */
   def stddev(m: Double = mean()): Double = {
     if (0 == size) return 0.0
-    val sum = iterator.map { case (k, v) => v * Math.pow(k.toDouble() - m, 2) }.sum
+    val sum = iterator.map { case (k, v) => v * Math.pow(k.toDouble - m, 2) }.sum
     if (0 == total) 0
-    else if (1== total) Math.sqrt(sum / this._totalMass.toDouble())
+    else if (1 == total) Math.sqrt(sum / this._totalMass.toDouble)
     else Math.sqrt(sum / (total - 1.0))
   }
 
@@ -99,7 +99,7 @@ class NumericCounter[T](implicit numeric: Numeric[T]) extends SimpleCounter[T] {
     val count: Long = total
 
     if (count == 0) 0.0
-    else if (count == 1) iterator.next()._1.toDouble()
+    else if (count == 1) iterator.next()._1.toDouble
     else {
       // Find the break point for finding the median value.  If we have an even # of items, we will need to average
       // two values.
@@ -126,7 +126,7 @@ class NumericCounter[T](implicit numeric: Numeric[T]) extends SimpleCounter[T] {
       }
 
       (midLowValue, midHighValue) match {
-        case (Some(low), Some(high)) => (low + high).toDouble() / 2.0
+        case (Some(low), Some(high)) => (low + high).toDouble / 2.0
         case _ => unreachable()
       }
     }
@@ -136,7 +136,7 @@ class NumericCounter[T](implicit numeric: Numeric[T]) extends SimpleCounter[T] {
   def mad(m: Double = median()): Double = {
     val deviations = new NumericCounter[Double]()
     this.iterator.foreach { case (value, count) =>
-      val deviation = Math.abs(value.toDouble() - m)
+      val deviation = Math.abs(value.toDouble - m)
       deviations.count(deviation, count)
     }
     deviations.median()

--- a/src/test/scala/com/fulcrumgenomics/commons/CommonsDefTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/CommonsDefTest.scala
@@ -223,7 +223,7 @@ class CommonsDefTest extends UnitSpec {
   "ParSupport" should "create a parallel collection with parallelism 2" in {
     val xs = Seq(1, 2, 3, 4, 5).parWith(parallelism = 2)
     xs.tasksupport.asInstanceOf[ForkJoinTaskSupport].forkJoinPool.getParallelism shouldBe 2
-    xs.map(_ * 2) shouldBe Seq(2, 4, 6, 8, 10)
+    xs.map(_ * 2).seq shouldBe Seq(2, 4, 6, 8, 10)
   }
 
   it should "allow setting of parallelism and async mode" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/async/AsyncRunnableTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/async/AsyncRunnableTest.scala
@@ -117,7 +117,7 @@ class AsyncRunnableTest extends UnitSpec with OptionValues {
   "AsyncRunnable.throwable" should "return the exception thrown in the run() method" in {
     val runnable = new AsyncRunnable {
       override protected def execute(): Unit = require(requirement=false, "exception")
-    } start()
+    }.start()
     runnable.started shouldBe true
     runnable.awaitDone()
     runnable.done shouldBe true
@@ -129,7 +129,7 @@ class AsyncRunnableTest extends UnitSpec with OptionValues {
     val runnable = new AsyncRunnable {
       override protected def execute(): Unit = require(requirement=false, "exception")
       override protected def uponException(): Unit = latch.countDown()
-    } start()
+    }.start()
     runnable.awaitDone()
     runnable.done shouldBe true
     runnable.throwable.isDefined shouldBe true
@@ -141,7 +141,7 @@ class AsyncRunnableTest extends UnitSpec with OptionValues {
     val runnable = new AsyncRunnable {
       override protected def execute(): Unit = require(requirement=false, "exception")
       override protected def uponFinally(): Unit = latch.countDown()
-    } start()
+    }.start()
     runnable.awaitDone()
     runnable.done shouldBe true
     runnable.throwable.isDefined shouldBe true
@@ -151,9 +151,9 @@ class AsyncRunnableTest extends UnitSpec with OptionValues {
   it should "be called when the run() method when the run method completes with no exception" in {
     val latch = new CountDownLatch(1)
     val runnable = new AsyncRunnable {
-      override protected def execute(): Unit = Unit
+      override protected def execute(): Unit = ()
       override protected def uponFinally(): Unit = latch.countDown()
-    } start()
+    }.start()
     runnable.awaitDone()
     runnable.done shouldBe true
     runnable.throwable.isDefined shouldBe false
@@ -164,7 +164,7 @@ class AsyncRunnableTest extends UnitSpec with OptionValues {
     val runnable = new AsyncRunnable {
       override protected def execute(): Unit = require(requirement=false, "exception")
       def check(): Unit = checkAndRaise()
-    } start()
+    }.start()
     runnable.awaitDone()
     an[RuntimeException] should be thrownBy runnable.check()
   }
@@ -173,9 +173,9 @@ class AsyncRunnableTest extends UnitSpec with OptionValues {
     // Create an AsyncRunnable that has a method that blocks.  Then create a thread with a runnable that calls the
     // blocking method.  Interrupt the latter thread, and make sure that a RunTimeException was thrown.
     val asyncRunnable = new AsyncRunnable {
-      override protected def execute(): Unit = Unit
+      override protected def execute(): Unit = ()
       def waitForIt(): Unit = tryAndModifyInterruptedException("waiting") { Thread.sleep(10000) }
-    } start()
+    }.start()
     val waitForItRunnable = new Runnable {
       var result: Option[Try[Unit]] = None
       override def run(): Unit = result = Some(Try { asyncRunnable.waitForIt() } )

--- a/src/test/scala/com/fulcrumgenomics/commons/async/AsyncSinkTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/async/AsyncSinkTest.scala
@@ -147,7 +147,7 @@ class AsyncSinkTest extends UnitSpec with OptionValues {
   it should "handle an exception thrown by the provided sink method" in {
     val writer = new Writer[String] {
       def write(item: String): Unit = throw new Exception
-      def close(): Unit = Unit
+      def close(): Unit = ()
     }
     val sink = new AsyncSink[String](sink = writer.write, source = Some(writer)).start()
     sink.add("item")

--- a/src/test/scala/com/fulcrumgenomics/commons/async/AsyncWriterPoolTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/async/AsyncWriterPoolTest.scala
@@ -79,7 +79,7 @@ class AsyncWriterPoolTest extends UnitSpec {
   it should "propagate exceptions thrown in writer threads" in {
     val writer = new Writer[String] {
       override def write(item: String): Unit = throw new UnsupportedOperationException
-      override def close(): Unit = Unit
+      override def close(): Unit = ()
     }
 
     val pool = new AsyncWriterPool(2)
@@ -90,7 +90,7 @@ class AsyncWriterPoolTest extends UnitSpec {
 
   it should "propagate exceptions thrown in close methods" in {
     val writer = new Writer[String] {
-      override def write(item: String): Unit = Unit
+      override def write(item: String): Unit = ()
       override def close(): Unit = throw new UnsupportedOperationException
     }
 

--- a/src/test/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtilTest.scala
@@ -196,7 +196,6 @@ class ReflectionUtilTest extends UnitSpec {
     it should "identify various classes that are not sub-classes of Seq[_] not as seq fields" in {
       val classes = List(
         classOf[scala.collection.Map[_, _]],
-        classOf[scala.collection.MapLike[_, _, _]],
         classOf[scala.collection.immutable.Map[_, _]],
         classOf[scala.collection.immutable.ListMap[_, _]],
         classOf[scala.collection.mutable.Map[_, _]],
@@ -229,7 +228,6 @@ class ReflectionUtilTest extends UnitSpec {
     it should "identify various classes that are not sub-classes of either Seq[_] or java.util.Collection[_] not as collection fields" in {
       val classes = List(
         classOf[scala.collection.Map[_, _]],
-        classOf[scala.collection.MapLike[_, _, _]],
         classOf[scala.collection.immutable.Map[_, _]],
         classOf[scala.collection.immutable.ListMap[_, _]],
         classOf[scala.collection.mutable.Map[_, _]],


### PR DESCRIPTION
This was more painful than I'd hoped.  A lot of the changes are small and related to two things:
1. You're no longer allowed to use `Unit` as an expression. So anywhere we had `def foo: Unit = Unit` has to be translated to `def foo: Unit = ()`.
2. The collections redesign, and specifically the move of parallel collections into a separate 2.13 specific artifact

As a result, to you `.par` anywhere you have to import a 2.13 specific class full of implicits (see https://github.com/scala/scala-parallel-collections/issues/22).  And because scala won't chain implicits, even if you could import that under 2.13 but not 2.12, it won't go `Seq` -> `NewImplicitWith.par` -> `ParSupport`.  As a result I've reworked `ParSupport` and the implicits around it.  As it stands it only supports parallelizing `Seq` and sub-types thereof, but on the plus side it's 2.12 and 2.13 compatible, and we should be able to add support for other types as we need them.