### PR TITLE
Removes as many deprecations as I can while still cross-building

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,3 +130,14 @@ lazy val root = Project(id="commons", base=file("."))
       }
     }
   )
+  .settings(
+    // Adds a `src/main/scala-2.13+` source directory for Scala 2.13 and newer
+    // and a `src/main/scala-2.12-` source directory for Scala version older than 2.13
+    unmanagedSourceDirectories in Compile += {
+      val sourceDir = (sourceDirectory in Compile).value
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n >= 13 => sourceDir / "scala-2.13+"
+        case _                       => sourceDir / "scala-2.12-"
+      }
+    }
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -113,8 +113,9 @@ lazy val root = Project(id="commons", base=file("."))
   .settings(description := "Scala commons for Fulcrum Genomics.")
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe"   %  "config"        % "1.3.2",
-      "org.scala-lang" %  "scala-reflect" % scalaVersion.value,
+      "com.typesafe"           %  "config"                  % "1.3.2",
+      "org.scala-lang"         %  "scala-reflect"           % scalaVersion.value,
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1",
       //---------- Test libraries -------------------//
       "org.scalatest"  %% "scalatest"     % "3.0.8"  % "test->*" excludeAll ExclusionRule(organization="org.junit", name="junit")
     )

--- a/src/main/scala-2.12-/com/fulcrumgenomics/commons/Compat.scala
+++ b/src/main/scala-2.12-/com/fulcrumgenomics/commons/Compat.scala
@@ -2,11 +2,13 @@ package com.fulcrumgenomics.commons
 
 import scala.annotation.ClassfileAnnotation
 
-/** Trait that includes types used for cross-building compatibility; scala 2.13 version. */
+/** Trait that includes types used for cross-building compatibility; scala 2.12 version. */
 private[commons] trait Compat {
-  /** For annotations available at runtime in 2.13 we use ConstantAnnotation. */
+  /** For annotations available at runtime in 2.12 we use ClassfileAnnotation which has been deprecated in
+    * 2.13 and replaced with the newly defined ConstantAnnotation.. */
   type ConstantAnnotation = scala.annotation.ClassfileAnnotation
 
-  /** For basic views we use the new scala.collection.View. */
+  /** For basic views in 2.12 we use the old scala.collection.IterableView which has disappeared in 2.13 to
+    * be replaced by View. */
   type View[+A] = scala.collection.IterableView[A, Iterable[A]]
 }

--- a/src/main/scala-2.12-/com/fulcrumgenomics/commons/Compat.scala
+++ b/src/main/scala-2.12-/com/fulcrumgenomics/commons/Compat.scala
@@ -1,0 +1,12 @@
+package com.fulcrumgenomics.commons
+
+import scala.annotation.ClassfileAnnotation
+
+/** Trait that includes types used for cross-building compatibility; scala 2.13 version. */
+private[commons] trait Compat {
+  /** For annotations available at runtime in 2.13 we use ConstantAnnotation. */
+  type ConstantAnnotation = scala.annotation.ClassfileAnnotation
+
+  /** For basic views we use the new scala.collection.View. */
+  type View[+A] = scala.collection.IterableView[A, Iterable[A]]
+}

--- a/src/main/scala-2.13+/com/fulcrumgenomics/commons/Compat.scala
+++ b/src/main/scala-2.13+/com/fulcrumgenomics/commons/Compat.scala
@@ -1,0 +1,10 @@
+package com.fulcrumgenomics.commons
+
+/** Trait that includes types used for cross-building compatibility; scala 2.13 version. */
+private[commons] trait Compat {
+  /** For annotations available at runtime in 2.13 we use ConstantAnnotation. */
+  type ConstantAnnotation = scala.annotation.ConstantAnnotation
+
+  /** For basic views we use the new scala.collection.View. */
+  type View[+A] = scala.collection.View[A]
+}

--- a/src/main/scala-2.13+/com/fulcrumgenomics/commons/Compat.scala
+++ b/src/main/scala-2.13+/com/fulcrumgenomics/commons/Compat.scala
@@ -7,4 +7,10 @@ private[commons] trait Compat {
 
   /** For basic views we use the new scala.collection.View. */
   type View[+A] = scala.collection.View[A]
+
+  /** Starting with scala 2.13 the default ordering of Floats is deprecated and we need to pick a preferred ordering. */
+  implicit val FloatOrdering: Ordering[Float] = scala.Ordering.Float.TotalOrdering
+
+  /** Starting with scala 2.13 the default ordering of Doubles is deprecated and we need to pick a preferred ordering. */
+  implicit val DoubleOrdering: Ordering[Double] = scala.Ordering.Double.TotalOrdering
 }

--- a/src/main/scala/com/fulcrumgenomics/commons/CommonsDef.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/CommonsDef.scala
@@ -158,7 +158,7 @@ class CommonsDef {
       * @tparam B the result type of the function f.
       * @return  the first `n` elements of this traversable or iterator with the largest values measured by function f.
       */
-    def maxNBy[B](n: Int, f: A => B, distinct: Boolean = false)(implicit cmp: Ordering[B]): Seq[A] = if (things.isEmpty || n == 0) Seq.empty[A] else {
+    def maxNBy[B](n: Int, f: A => B, distinct: Boolean = false)(implicit cmp: Ordering[B]): Seq[A] = if (n == 0) Seq.empty[A] else {
       // Developer Note: a future improvement would be to determine when to use maxNBySmall vs. maxNByLarge.  Also,
       // if we want to get n items from a sequence that is close to length m, we could find the m-n items to remove, as
       // to save memory.
@@ -214,7 +214,7 @@ class CommonsDef {
       val toThingAndValue: (A, Int) => ThingAndValue[B] = {
         if (distinct) (t: A, _: Int) => ThingAndValue(t, f(t)) else (t: A, i: Int) => ThingAndValue(t, f(t), i)
       }
-      this.things.toIterator.zipWithIndex.foreach { case (thing, index) =>
+      this.things.iterator.zipWithIndex.foreach { case (thing, index) =>
         val thingAndValue = toThingAndValue(thing, index)
         // If we haven't reached N yet, add it.  If the last element is "smaller" than the curret one, add it.  Otherwise, don't!
         if (orderedThings.isEmpty || orderedThings.size() < n) orderedThings.add(thingAndValue)
@@ -342,7 +342,7 @@ class CommonsDef {
       * @tparam B the type of the items after the transform has been applied; must be a [[Numeric]] type.
       * @return
       */
-    def sumBy[B](f: A => B)(implicit x: Numeric[B]): B = sequence.foldLeft(x.zero) { case (left, right) => x.plus(left, f(right)) }
+    def sumBy[B](f: A => B)(implicit x: Numeric[B]): B = sequence.iterator.foldLeft(x.zero) { case (left, right) => x.plus(left, f(right)) }
   }
 
   /**

--- a/src/main/scala/com/fulcrumgenomics/commons/CommonsDef.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/CommonsDef.scala
@@ -44,7 +44,7 @@ import scala.util.{Failure, Success, Try}
   * New methods, types and objects should not be added to this class lightly as they
   * will pollute the namespace of any classes which import it.
   */
-class CommonsDef {
+trait CommonsDef extends Compat {
   /** An exception that implies that code is unreachable. */
   private class UnreachableException(message: String) extends IllegalStateException(message)
 

--- a/src/main/scala/com/fulcrumgenomics/commons/CommonsDef.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/CommonsDef.scala
@@ -29,12 +29,11 @@ import java.io.Closeable
 import com.fulcrumgenomics.commons.collection.BetterBufferedIterator
 import com.fulcrumgenomics.commons.util.Logger
 
+import scala.collection.compat._
 import scala.collection.parallel.immutable
 import scala.collection.parallel.{ForkJoinTaskSupport, ParIterable, TaskSupport}
 import java.util.concurrent.ForkJoinPool
 
-import scala.collection.parallel.immutable.{ParRange, ParVector}
-import scala.collection.parallel.mutable.ParArray
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
@@ -140,7 +139,7 @@ class CommonsDef {
     }
   }
 
-  implicit class MaxNBy[A](val things: TraversableOnce[A]) {
+  implicit class MaxNBy[A](val things: IterableOnce[A]) {
     /** Finds the first `n` elements with the largest values.
       *
       * @param n the number of elements return.
@@ -335,7 +334,7 @@ class CommonsDef {
     * @param sequence the sequence of items to transform and sum.
     * @tparam A the type of items to transform.
     */
-  implicit class SumBy[A](sequence: TraversableOnce[A]) {
+  implicit class SumBy[A](sequence: IterableOnce[A]) {
     /**
       * Applies the given transform to the items in sequence, and then sums them.
       * @param f the transform to map items from type [[A]] to type [[B]].

--- a/src/main/scala/com/fulcrumgenomics/commons/collection/BetterBufferedIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/collection/BetterBufferedIterator.scala
@@ -26,6 +26,8 @@ package com.fulcrumgenomics.commons.collection
 
 import com.fulcrumgenomics.commons.CommonsDef._
 
+import scala.collection.BufferedIterator
+
 /** A little trait to allow BetterBufferedIterator to override the headOption method. The latter method
   * is not found in [[BetterBufferedIterator]] in 2.11.11, but in 2.12.2! */
 sealed trait HeadOption[A] {

--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -78,7 +78,7 @@ trait IoUtil {
   }
 
   /** Asserts that the Path represents a file that can be opened and read. */
-  def assertReadable(paths : IterableOnce[_ <: Path]) : Unit = paths.foreach(assertReadable)
+  def assertReadable(paths : IterableOnce[_ <: Path]) : Unit = paths.iterator.foreach(assertReadable)
 
   /** Asserts that the Paths represents files that can be opened and read. */
   def assertReadable(path: Path) : Unit = {
@@ -89,7 +89,7 @@ trait IoUtil {
   }
 
   /** Asserts that the Paths represent directories that can be listed. */
-  def assertListable(paths : IterableOnce[_ <: Path]) : Unit = paths.foreach(assertListable)
+  def assertListable(paths : IterableOnce[_ <: Path]) : Unit = paths.iterator.foreach(assertListable)
 
   /** Asserts that the Path represents a directory that can be listed. */
   def assertListable(path: Path) : Unit = {
@@ -108,7 +108,7 @@ trait IoUtil {
     *                        require that the first parent that actually exists is writable
     */
   def assertCanWriteFiles(paths : IterableOnce[_ <: Path], parentMustExist:Boolean = true) : Unit = {
-    paths.foreach(p => assertCanWriteFile(p, parentMustExist))
+    paths.iterator.foreach(p => assertCanWriteFile(p, parentMustExist))
   }
 
   /**
@@ -138,7 +138,7 @@ trait IoUtil {
   }
 
   /** Asserts that a path represents an existing directory and that new files can be created within the directory. */
-  def assertWritableDirectory(paths : IterableOnce[_ <: Path]) : Unit = paths.foreach(assertWritableDirectory)
+  def assertWritableDirectory(paths : IterableOnce[_ <: Path]) : Unit = paths.iterator.foreach(assertWritableDirectory)
 
   /** Asserts that a path represents an existing directory and that new files can be created within the directory. */
   def assertWritableDirectory(path : Path) : Unit = {
@@ -175,7 +175,7 @@ trait IoUtil {
   /** Writes one or more lines to a file represented by a path. */
   def writeLines(path: Path, lines: IterableOnce[String]): Unit = {
     val writer = toWriter(path)
-    lines.foreach(line => writer.append(line).append('\n'))
+    lines.iterator.foreach(line => writer.append(line).append('\n'))
     writer.close()
   }
 

--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -28,6 +28,7 @@ import java.nio.file.{Files, Path}
 
 import com.fulcrumgenomics.commons.CommonsDef._
 
+import scala.collection.compat._
 import scala.io.Source
 
 /**
@@ -77,7 +78,7 @@ trait IoUtil {
   }
 
   /** Asserts that the Path represents a file that can be opened and read. */
-  def assertReadable(paths : TraversableOnce[_ <: Path]) : Unit = paths.foreach(assertReadable)
+  def assertReadable(paths : IterableOnce[_ <: Path]) : Unit = paths.foreach(assertReadable)
 
   /** Asserts that the Paths represents files that can be opened and read. */
   def assertReadable(path: Path) : Unit = {
@@ -88,7 +89,7 @@ trait IoUtil {
   }
 
   /** Asserts that the Paths represent directories that can be listed. */
-  def assertListable(paths : TraversableOnce[_ <: Path]) : Unit = paths.foreach(assertListable)
+  def assertListable(paths : IterableOnce[_ <: Path]) : Unit = paths.foreach(assertListable)
 
   /** Asserts that the Path represents a directory that can be listed. */
   def assertListable(path: Path) : Unit = {
@@ -106,7 +107,7 @@ trait IoUtil {
     * @param parentMustExist if true (default) the file or its direct parent must exist, if false then only
     *                        require that the first parent that actually exists is writable
     */
-  def assertCanWriteFiles(paths : TraversableOnce[_ <: Path], parentMustExist:Boolean = true) : Unit = {
+  def assertCanWriteFiles(paths : IterableOnce[_ <: Path], parentMustExist:Boolean = true) : Unit = {
     paths.foreach(p => assertCanWriteFile(p, parentMustExist))
   }
 
@@ -137,7 +138,7 @@ trait IoUtil {
   }
 
   /** Asserts that a path represents an existing directory and that new files can be created within the directory. */
-  def assertWritableDirectory(paths : TraversableOnce[_ <: Path]) : Unit = paths.foreach(assertWritableDirectory)
+  def assertWritableDirectory(paths : IterableOnce[_ <: Path]) : Unit = paths.foreach(assertWritableDirectory)
 
   /** Asserts that a path represents an existing directory and that new files can be created within the directory. */
   def assertWritableDirectory(path : Path) : Unit = {
@@ -172,7 +173,7 @@ trait IoUtil {
   }
 
   /** Writes one or more lines to a file represented by a path. */
-  def writeLines(path: Path, lines: TraversableOnce[String]): Unit = {
+  def writeLines(path: Path, lines: IterableOnce[String]): Unit = {
     val writer = toWriter(path)
     lines.foreach(line => writer.append(line).append('\n'))
     writer.close()

--- a/src/main/scala/com/fulcrumgenomics/commons/io/Writer.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Writer.scala
@@ -33,7 +33,7 @@ trait Writer[A] extends Closeable {
   def write(item: A): Unit
 
   /** Writes out one or more items in order. */
-  def write[B <: A](items: IterableOnce[B]): Unit = items.foreach(write)
+  def write[B <: A](items: IterableOnce[B]): Unit = items.iterator.foreach(write)
 
   /** Writes an item and returns a reference to the writer. */
   def +=(item: A): this.type = {

--- a/src/main/scala/com/fulcrumgenomics/commons/io/Writer.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Writer.scala
@@ -25,6 +25,7 @@
 package com.fulcrumgenomics.commons.io
 
 import java.io.Closeable
+import scala.collection.compat._
 
 /** Writer trait to standardize how to interact with classes that write out objects. */
 trait Writer[A] extends Closeable {
@@ -32,7 +33,7 @@ trait Writer[A] extends Closeable {
   def write(item: A): Unit
 
   /** Writes out one or more items in order. */
-  def write[B <: A](items: TraversableOnce[B]): Unit = items.foreach(write)
+  def write[B <: A](items: IterableOnce[B]): Unit = items.foreach(write)
 
   /** Writes an item and returns a reference to the writer. */
   def +=(item: A): this.type = {
@@ -41,7 +42,7 @@ trait Writer[A] extends Closeable {
   }
 
   /** Writes an item and returns a reference to the writer. */
-  def ++=[B <: A](items: TraversableOnce[B]): this.type = {
+  def ++=[B <: A](items: IterableOnce[B]): this.type = {
     write(items)
     this
   }

--- a/src/main/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtil.scala
@@ -26,12 +26,11 @@ package com.fulcrumgenomics.commons.reflect
 import java.lang.reflect.{Constructor, InvocationTargetException}
 import java.nio.file.Path
 
-import com.fulcrumgenomics.commons.io.PathUtil
 import com.fulcrumgenomics.commons.CommonsDef._
+import com.fulcrumgenomics.commons.io.PathUtil
 
-import scala.language.postfixOps
-import scala.annotation.{ClassfileAnnotation, tailrec}
 import scala.collection.mutable
+import scala.language.postfixOps
 import scala.reflect._
 import scala.reflect.runtime.universe._
 import scala.reflect.runtime.{universe => ru}
@@ -155,7 +154,7 @@ object ReflectionUtil {
     * Returns true if the symbol (class, field, arg) is annotated with a scala classfile annotation
     * of the provided type, otherwise returns false.
     */
-  def hasScalaAnnotation[A <: ClassfileAnnotation](sym: Symbol)(implicit evidence: ru.TypeTag[A]): Boolean = {
+  def hasScalaAnnotation[A <: ConstantAnnotation](sym: Symbol)(implicit evidence: ru.TypeTag[A]): Boolean = {
     val annotationType = mirror.typeOf[A]
     sym.annotations.exists(a => a.tree.tpe == annotationType)
   }
@@ -164,7 +163,7 @@ object ReflectionUtil {
     * Returns true if the class of type C the symbol is annotated with a scala classfile annotation
     * of type A, otherwise returns false.
     */
-  def hasScalaAnnotation[A <: ClassfileAnnotation, C <: Any](implicit evA: ru.TypeTag[A], evC: ru.TypeTag[C]): Boolean = {
+  def hasScalaAnnotation[A <: ConstantAnnotation, C <: Any](implicit evA: ru.TypeTag[A], evC: ru.TypeTag[C]): Boolean = {
     hasScalaAnnotation[A](mirror.typeOf[C].typeSymbol)
   }
 
@@ -173,7 +172,7 @@ object ReflectionUtil {
     * preferred when, in code, the _type_ of class is known directly. Otherwise see the version which takes
     * an annotated symbol instead of a type.
     * */
-  def findScalaAnnotation[A <: ClassfileAnnotation, C <: Any](implicit evA: ru.TypeTag[A], evC: ru.TypeTag[C]): Option[A] = {
+  def findScalaAnnotation[A <: ConstantAnnotation, C <: Any](implicit evA: ru.TypeTag[A], evC: ru.TypeTag[C]): Option[A] = {
     findScalaAnnotation[A](mirror.typeOf[C].typeSymbol)
   }
 
@@ -182,7 +181,7 @@ object ReflectionUtil {
     * with the specified annotation, None is returned. If it is annotated then the annotation value is reified
     * and an instance returned.
     */
-  def findScalaAnnotation[A <: ClassfileAnnotation](sym: Symbol)(implicit evidence: ru.TypeTag[A]): Option[A] = {
+  def findScalaAnnotation[A <: ConstantAnnotation](sym: Symbol)(implicit evidence: ru.TypeTag[A]): Option[A] = {
     val annotationType = mirror.typeOf[A]
     val annotationOption = sym.annotations.find(a => a.tree.tpe == annotationType)
     annotationOption.map(ann => {

--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -28,6 +28,7 @@ import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.io.Io
 import com.fulcrumgenomics.commons.reflect.ReflectionUtil
 
+import scala.collection.compat._
 import scala.reflect.runtime.{universe => ru}
 
 /**
@@ -89,11 +90,11 @@ object DelimitedDataParser {
     apply(Io.toSource(path).getLines(), delimiter=delimiter, header=header)
 
   /** Constructs a DelimitedDataParser for a sequence of lines. */
-  def apply(lines: TraversableOnce[String], delimiter: Char): DelimitedDataParser =
+  def apply(lines: IterableOnce[String], delimiter: Char): DelimitedDataParser =
     apply(lines, delimiter=delimiter, header=Seq.empty)
 
   /** Constructs a DelimitedDataParser for a sequence of lines. */
-  def apply(lines: TraversableOnce[String], delimiter: Char, header: Seq[String]): DelimitedDataParser =
+  def apply(lines: IterableOnce[String], delimiter: Char, header: Seq[String]): DelimitedDataParser =
     new DelimitedDataParser(lines, delimiter=delimiter, header=header)
 }
 
@@ -106,7 +107,7 @@ object DelimitedDataParser {
   * @param trimFields whether individual fields should have their String values trimmed
   * @param header the header names for the columns of delimited data. If empty, the first line should contain the header names.
   */
-class DelimitedDataParser(lines: TraversableOnce[String],
+class DelimitedDataParser(lines: IterableOnce[String],
                           val delimiter: Char,
                           val ignoreBlankLines: Boolean = DelimitedDataParser.DefaultBlankPolicy,
                           val trimFields: Boolean = DelimitedDataParser.DefaultTrim,

--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -113,7 +113,7 @@ class DelimitedDataParser(lines: IterableOnce[String],
                           val trimFields: Boolean = DelimitedDataParser.DefaultTrim,
                           val header: Seq[String] = Seq.empty) extends Iterator[Row] with LazyLogging {
 
-  private val _lines = if (ignoreBlankLines) lines.toIterator.filter(_.nonEmpty) else lines.toIterator
+  private val _lines = if (ignoreBlankLines) lines.iterator.filter(_.nonEmpty) else lines.iterator
 
   // An array of the headers
   private val _headers = {

--- a/src/main/scala/com/fulcrumgenomics/commons/util/Logger.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/Logger.scala
@@ -53,7 +53,7 @@ class Logger(clazz : Class[_]) {
     if (l.compareTo(Logger.level) >= 0) {
       val builder = new StringBuilder(256)
       builder.append("[").append(fmt.format(new Date())).append(" | ").append(name).append(" | ").append(l.toString).append("] ")
-      parts.foreach(part => builder.append(part))
+      parts.iterator.foreach(part => builder.append(part))
       this.out match {
         case Some(o) => o.println(builder.toString())
         case _ => Logger.out.println(builder.toString())

--- a/src/main/scala/com/fulcrumgenomics/commons/util/Logger.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/Logger.scala
@@ -27,6 +27,8 @@ import java.io.{PrintStream, PrintWriter, StringWriter}
 import java.text.SimpleDateFormat
 import java.util.Date
 
+import scala.collection.compat._
+
 /** Companion object for the Logger class that holds the system-wide log level, and a PrintWriter to write to. */
 object Logger {
   var level = LogLevel.Info
@@ -47,7 +49,7 @@ class Logger(clazz : Class[_]) {
   var out: Option[PrintStream] = None
 
   /** Checks to see if a message should be emitted given the current log level, and then emits atomically. */
-  protected def emit(l: LogLevel, parts: TraversableOnce[Any]) : Unit = {
+  protected def emit(l: LogLevel, parts: IterableOnce[Any]) : Unit = {
     if (l.compareTo(Logger.level) >= 0) {
       val builder = new StringBuilder(256)
       builder.append("[").append(fmt.format(new Date())).append(" | ").append(name).append(" | ").append(l.toString).append("] ")

--- a/src/main/scala/com/fulcrumgenomics/commons/util/NumericCounter.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/NumericCounter.scala
@@ -27,18 +27,19 @@ package com.fulcrumgenomics.commons.util
 
 import com.fulcrumgenomics.commons.CommonsDef._
 
+import scala.collection.compat._
 import scala.collection.mutable
 
 object NumericCounter {
   /** Generates a counter that has counted all the numerics provided. */
-  def apply[T](ts: TraversableOnce[T])(implicit numeric: Numeric[T]) : NumericCounter[T] = {
+  def apply[T](ts: IterableOnce[T])(implicit numeric: Numeric[T]) : NumericCounter[T] = {
     val counter = new NumericCounter[T]
     ts.foreach(counter.count)
     counter
   }
 
   /** Generates a counter that has counted all the numerics provided. */
-  def from[T](ts: TraversableOnce[(T, Long)])(implicit numeric: Numeric[T]) : NumericCounter[T] = {
+  def from[T](ts: IterableOnce[(T, Long)])(implicit numeric: Numeric[T]) : NumericCounter[T] = {
     val counter = new NumericCounter[T]
     ts.foreach { case (value, count) => counter.count(value, count) }
     counter

--- a/src/main/scala/com/fulcrumgenomics/commons/util/NumericCounter.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/NumericCounter.scala
@@ -34,14 +34,14 @@ object NumericCounter {
   /** Generates a counter that has counted all the numerics provided. */
   def apply[T](ts: IterableOnce[T])(implicit numeric: Numeric[T]) : NumericCounter[T] = {
     val counter = new NumericCounter[T]
-    ts.foreach(counter.count)
+    ts.iterator.foreach(counter.count)
     counter
   }
 
   /** Generates a counter that has counted all the numerics provided. */
   def from[T](ts: IterableOnce[(T, Long)])(implicit numeric: Numeric[T]) : NumericCounter[T] = {
     val counter = new NumericCounter[T]
-    ts.foreach { case (value, count) => counter.count(value, count) }
+    ts.iterator.foreach { case (value, count) => counter.count(value, count) }
     counter
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/commons/util/SimpleCounter.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/SimpleCounter.scala
@@ -23,14 +23,13 @@
  */
 package com.fulcrumgenomics.commons.util
 
-import java.util
-
+import scala.collection.compat._
 import scala.reflect.runtime.universe._
 import scala.collection.mutable
 
 object SimpleCounter {
   /** Generates a counter that has counted all the objects provided. */
-  def apply[T](ts: TraversableOnce[T])(implicit tt: TypeTag[T]) : SimpleCounter[T] = {
+  def apply[T](ts: IterableOnce[T])(implicit tt: TypeTag[T]) : SimpleCounter[T] = {
     val counter = new SimpleCounter[T]
     ts.foreach(counter.count)
     counter

--- a/src/main/scala/com/fulcrumgenomics/commons/util/SimpleCounter.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/SimpleCounter.scala
@@ -31,7 +31,7 @@ object SimpleCounter {
   /** Generates a counter that has counted all the objects provided. */
   def apply[T](ts: IterableOnce[T])(implicit tt: TypeTag[T]) : SimpleCounter[T] = {
     val counter = new SimpleCounter[T]
-    ts.foreach(counter.count)
+    ts.iterator.foreach(counter.count)
     counter
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/commons/util/Threads.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/Threads.scala
@@ -25,7 +25,7 @@
 
 package com.fulcrumgenomics.commons.util
 
-import com.fulcrumgenomics.commons.CommonsDef.javaIterableToIterator
+import com.fulcrumgenomics.commons.CommonsDef._
 
 object Threads {
 
@@ -48,6 +48,6 @@ object Threads {
       *
       * Care should be taken accessing the iterator since objects may be in use by other threads.
       */
-    def iterator: Iterator[A] = all.toIterator
+    def iterator: Iterator[A] = all.iterator()
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/commons/CommonsDefTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/CommonsDefTest.scala
@@ -130,9 +130,9 @@ class CommonsDefTest extends UnitSpec {
   }
 
   "CommonsDef.maxN" should "return the maximum N elements" in {
-    Seq.empty[Int].maxN(0) shouldBe 'empty
-    Seq(1,2,3,4).maxN(0) shouldBe 'empty
-    Seq.empty[Int].maxN(1) shouldBe 'empty
+    Seq.empty[Int].maxN(0).isEmpty shouldBe true
+    Seq(1,2,3,4).maxN(0).isEmpty shouldBe true
+    Seq.empty[Int].maxN(1).isEmpty shouldBe true
     val seq    = Seq(5,3,7,1,2,5,8,12,14,22)
     val sorted = seq.sortBy(s => -s)
     Range.inclusive(start=1, end=seq.length*2).foreach { n => // tests asking both fewer and more than the # of elements
@@ -142,9 +142,9 @@ class CommonsDefTest extends UnitSpec {
   }
 
   "CommonsDef.maxNBy" should "return the maximum N elements compared by a given method" in {
-    Seq.empty[Int].maxNBy(0, identity) shouldBe 'empty
-    Seq(1,2,3,4).maxNBy(0, identity) shouldBe 'empty
-    Seq.empty[Int].maxNBy(1, identity) shouldBe 'empty
+    Seq.empty[Int].maxNBy(0, identity).isEmpty shouldBe true
+    Seq(1,2,3,4).maxNBy(0, identity).isEmpty shouldBe true
+    Seq.empty[Int].maxNBy(1, identity).isEmpty shouldBe true
     val seq    = Seq(5,3,7,1,2,5,8,12,14,22)
     val sorted = seq.sorted
     Range.inclusive(start=1, end=seq.length*2).foreach { n => // tests asking both fewer and more than the # of elements
@@ -201,21 +201,21 @@ class CommonsDefTest extends UnitSpec {
   }
 
   "sumBy[B]" should "sum a non-empty sequence of values" in {
-    val traversable     = Traversable("1", "2", "3")
+    val iterable        = Iterable("1", "2", "3")
     val iterator        = Iterator("1", "2", "3")
     val list            = List("1", "2", "3")
 
-    traversable.sumBy(_.toInt) shouldBe 6
+    iterable.sumBy(_.toInt) shouldBe 6
     iterator.sumBy(_.toInt) shouldBe 6
     list.sumBy(_.toInt) shouldBe 6
   }
 
   "sumBy[B]" should "sum an empty sequence" in {
-    val traversable     = Traversable.empty[String]
+    val iterable        = Iterable.empty[String]
     val iterator        = Iterator[String]()
     val list            = List.empty[String]
 
-    traversable.sumBy(_.toInt) shouldBe 0
+    iterable.sumBy(_.toInt) shouldBe 0
     iterator.sumBy(_.toInt) shouldBe 0
     list.sumBy(_.toInt) shouldBe 0
   }

--- a/src/test/scala/com/fulcrumgenomics/commons/async/AsyncIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/async/AsyncIteratorTest.scala
@@ -33,14 +33,14 @@ class AsyncIteratorTest extends UnitSpec with OptionValues {
   "AsyncIterator" should "wrap an empty iterator" in {
     val iter = new AsyncIterator(Iterator[String]()).start()
     iter.hasNext shouldBe false
-    iter shouldBe 'empty
+    iter.isEmpty shouldBe true
     an[NoSuchElementException] should be thrownBy iter.next()
   }
 
   Seq((10, "fewer"), (20, "the same number of"), (30, "more")).foreach { case (numItems, msg) =>
     it should s"wrap an iterator that has $msg items than bufferSize" in {
       val source = Seq.range(start=0, end=numItems)
-      val items = new AsyncIterator(source.toIterator, bufferSize=Some(20)).start().toList
+      val items = new AsyncIterator(source.iterator, bufferSize=Some(20)).start().toList
       items should contain theSameElementsInOrderAs source
     }
   }

--- a/src/test/scala/com/fulcrumgenomics/commons/async/AsyncSinkTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/async/AsyncSinkTest.scala
@@ -53,7 +53,7 @@ class AsyncSinkTest extends UnitSpec with OptionValues {
 
   /** Returns a [[RunnableWithResult]] that asynchronously adds the items to the given sink, along with a daemon
     * [[Thread]] that is created containing the [[RunnableWithResult]] and is started. */
-  private def buildRunnableAndThreadForSinkAdd[T](sink: AsyncSink[T], items: Traversable[T]): (RunnableWithResult, Thread) = {
+  private def buildRunnableAndThreadForSinkAdd[T](sink: AsyncSink[T], items: Iterable[T]): (RunnableWithResult, Thread) = {
     buildRunnableAndThread(items.foreach(sink.add))
   }
 
@@ -61,7 +61,7 @@ class AsyncSinkTest extends UnitSpec with OptionValues {
     {
       val writer = new StringWriter
       val sink = new AsyncSink[String](sink = writer.write, source = Some(writer)).start().close()
-      writer.items shouldBe 'empty
+      writer.items.isEmpty shouldBe true
       writer.closed shouldBe true
     }
 
@@ -69,7 +69,7 @@ class AsyncSinkTest extends UnitSpec with OptionValues {
     {
       val writer = new StringWriter
       new AsyncSink[String](sink=writer.write, source=None).start().close()
-      writer.items shouldBe 'empty
+      writer.items.isEmpty shouldBe true
       writer.closed shouldBe false
     }
   }
@@ -94,13 +94,13 @@ class AsyncSinkTest extends UnitSpec with OptionValues {
       if (bufferSize < numItems) { // blocks when adding to the writer, so the queue will fill up, and we'll block adding
         Thread.sleep(100)
         runnable.done shouldBe false
-        writer.items shouldBe 'empty
+        writer.items.isEmpty shouldBe true
       }
       else { // queue size is more than the # of items, so the runnable should be able to add to the sink
         thread.join(10000) // wait for the thread to complete
         runnable.done shouldBe true
       }
-      writer.items shouldBe 'empty
+      writer.items.isEmpty shouldBe true
 
       // unblock
       writer.block = false
@@ -139,7 +139,7 @@ class AsyncSinkTest extends UnitSpec with OptionValues {
     runnable.result.value.isSuccess shouldBe false
     runnable.result.value.failed.get.getMessage shouldBe "Interrupted queueing item."
     runnable.result.value.failed.get.isInstanceOf[RuntimeException] shouldBe true
-    sink.throwable shouldBe 'empty
+    sink.throwable.isEmpty shouldBe true
 
     sink.close()
   }

--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -152,7 +152,7 @@ class IoTest extends UnitSpec {
   }
 
   it should "return None if no parent was found" in {
-    Io.findFirstExtentParent(PathUtil.pathTo("/")) shouldBe 'empty
+    Io.findFirstExtentParent(PathUtil.pathTo("/")).isEmpty shouldBe true
   }
 
   "Io.writeLines" should "write lines to a file that can be read back." in {

--- a/src/test/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtilTest.scala
@@ -26,14 +26,12 @@ package com.fulcrumgenomics.commons.reflect
 import java.util
 import java.util.concurrent.TimeUnit
 
+import com.fulcrumgenomics.commons.CommonsDef._
 import com.fulcrumgenomics.commons.io.PathUtil
-import com.fulcrumgenomics.commons.util.{LogLevel, UnitSpec}
 import com.fulcrumgenomics.commons.reflect.ReflectionUtilTest.SecondaryConstructor
+import com.fulcrumgenomics.commons.util.{LogLevel, UnitSpec}
 
-import scala.annotation.ClassfileAnnotation
 import scala.reflect.runtime.{universe => ru}
-import scala.reflect.runtime.universe._
-import scala.reflect.ClassTag
 import scala.util.Success
 
 object ReflectionUtilTest {
@@ -433,7 +431,7 @@ class ReflectionUtilTest extends UnitSpec {
 
 
 /** Annotation that is used in testing the findAnnotation method (has to be outer class). */
-case class Ann(s:String = "foo", i:Int = 42, b:Boolean=false) extends ClassfileAnnotation
+case class Ann(s:String = "foo", i:Int = 42, b:Boolean=false) extends ConstantAnnotation
 @Ann class NoValues
 @Ann(s="Hello") class Hello
 @Ann(s="Hello", i=101, b=true) class Hello101True
@@ -441,23 +439,23 @@ case class Ann(s:String = "foo", i:Int = 42, b:Boolean=false) extends ClassfileA
 @Ann(s=java.util.jar.JarFile.MANIFEST_NAME, i=Integer.MAX_VALUE) class WithConstRefs
 
 /* Purposefully not a case class, to test both case and non-case class annotations. */
-class EnumAnn(val e:TimeUnit= TimeUnit.MINUTES) extends ClassfileAnnotation {
+class EnumAnn(val e:TimeUnit= TimeUnit.MINUTES) extends ConstantAnnotation {
   override def equals(that: scala.Any): Boolean = this.e == that.asInstanceOf[EnumAnn].e
 }
 @EnumAnn class EnumAnnotated
 @EnumAnn(e=TimeUnit.DAYS) class EnumAnnotatedWaiting
 
-case class InnerEnumAnn(state: Thread.State = Thread.State.NEW) extends ClassfileAnnotation
+case class InnerEnumAnn(state: Thread.State = Thread.State.NEW) extends ConstantAnnotation
 @InnerEnumAnn(state=Thread.State.BLOCKED) class InnerEnumAnnotated
 
-case class ArrayAnn(ss: Array[String] = Array()) extends ClassfileAnnotation {
+case class ArrayAnn(ss: Array[String] = Array()) extends ConstantAnnotation {
   override def equals(that: scala.Any): Boolean = this.ss.toSeq == that.asInstanceOf[ArrayAnn].ss.toSeq
   override def toString: String = "@ArrayAnn(ss=" + ss.mkString("[", ", ", "]") + ")"
 }
 @ArrayAnn class ArrWithDefault
 @ArrayAnn(ss=Array("foo", "bar", "splat")) class ArrWithElems
 
-case class ClassAnn(c: Class[_] = classOf[Any]) extends ClassfileAnnotation
+case class ClassAnn(c: Class[_] = classOf[Any]) extends ConstantAnnotation
 @ClassAnn(c=classOf[Thread]) class ClassAnnotated
 @Ann object SomeEnum extends Enumeration {
   val Mon,Tue,Wed,Thu,Fri = Value
@@ -492,19 +490,19 @@ class ReflectUtilAnnotationTest extends UnitSpec {
   it should "work with Java enums" in {
     ReflectionUtil.findScalaAnnotation[EnumAnn,EnumAnnotated] shouldBe Some(new EnumAnn())
     ReflectionUtil.findScalaAnnotation[EnumAnn,EnumAnnotatedWaiting] shouldBe Some(new EnumAnn(TimeUnit.DAYS))
-    ReflectionUtil.findScalaAnnotation[InnerEnumAnn,InnerEnumAnnotated] shouldBe Some(new InnerEnumAnn(Thread.State.BLOCKED))
+    ReflectionUtil.findScalaAnnotation[InnerEnumAnn,InnerEnumAnnotated] shouldBe Some(InnerEnumAnn(Thread.State.BLOCKED))
   }
 
   it should "work with an array parameter with default value" in {
-    ReflectionUtil.findScalaAnnotation[ArrayAnn,ArrWithDefault] shouldBe Some(new ArrayAnn())
+    ReflectionUtil.findScalaAnnotation[ArrayAnn,ArrWithDefault] shouldBe Some(ArrayAnn())
   }
 
   it should "work with an array parameter with one value" in {
-    ReflectionUtil.findScalaAnnotation[ArrayAnn,ArrWithElems] shouldBe Some(new ArrayAnn(ss=Array("foo", "bar", "splat")))
+    ReflectionUtil.findScalaAnnotation[ArrayAnn,ArrWithElems] shouldBe Some(ArrayAnn(ss=Array("foo", "bar", "splat")))
   }
 
   it should "work with Class values in annotations" in {
-    ReflectionUtil.findScalaAnnotation[ClassAnn,ClassAnnotated] shouldBe Some(new ClassAnn(c=classOf[Thread]))
+    ReflectionUtil.findScalaAnnotation[ClassAnn,ClassAnnotated] shouldBe Some(ClassAnn(c=classOf[Thread]))
   }
 
   it should "work with Scala Enumerations" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/reflect/ReflectionUtilTest.scala
@@ -397,13 +397,13 @@ class ReflectionUtilTest extends UnitSpec {
 
   "ReflectionUtil.enumOptions" should "return the options for an enum" in {
     val options = ReflectionUtil.enumOptions(classOf[GoodEnum])
-    options shouldBe 'success
+    options.isSuccess shouldBe true
     options.get should contain (GoodEnum.GOOD)
     options.get should contain (GoodEnum.BOY)
   }
 
   it should "fail when there are no options for an enum" in {
-    ReflectionUtil.enumOptions(classOf[BadEnum]) shouldBe 'failure
+    ReflectionUtil.enumOptions(classOf[BadEnum]).isFailure shouldBe true
   }
 
   "ReflectionUtil.sealedTraitOptions" should "find the possible values in a sealed trait/case object hierarchy with a values method" in {
@@ -417,11 +417,11 @@ class ReflectionUtilTest extends UnitSpec {
   }
 
   it should "fail when the class is not a sealed trait" in {
-    ReflectionUtil.sealedTraitOptions(classOf[GoodEnum]) shouldBe 'failure
+    ReflectionUtil.sealedTraitOptions(classOf[GoodEnum]).isFailure shouldBe true
   }
 
   it should "fail when the sub-classes are not case objects" in {
-    ReflectionUtil.sealedTraitOptions(classOf[CaseClasses]) shouldBe 'failure
+    ReflectionUtil.sealedTraitOptions(classOf[CaseClasses]).isFailure shouldBe true
   }
 
   "ReflectionUtil.buildUnitFromString" should "throw an Exception when an unknown enum value is given" in {
@@ -518,7 +518,7 @@ class ReflectUtilAnnotationTest extends UnitSpec {
 
   "ReflectionUtil.findJavaAnnotation" should "return the annotation on a class" in {
     val value = ReflectionUtil.findJavaAnnotation(clazz=classOf[ClassJavaAnnotation], annotationClazz=classOf[TestJavaAnnotation])
-    value shouldBe 'defined
+    value.isDefined shouldBe true
     //value.get.getClass shouldBe classOf[TestJavaAnnotation]
     value.map(_.placeholder()) shouldBe Some("value")
   }

--- a/src/test/scala/com/fulcrumgenomics/commons/util/ConfigurationLikeTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/ConfigurationLikeTest.scala
@@ -88,9 +88,9 @@ class ConfigurationLikeTest extends UnitSpec with CaptureSystemStreams with Opti
     conf[Set[String]]("some-string-set") should contain theSameElementsAs Set("A", "B", "C")
     conf[Option[String]]("some-option-string").value shouldBe "Some"
     conf[Option[String]]("option-empty-string").value shouldBe ""
-    conf[Option[String]]("none-option-string") shouldBe 'empty
+    conf[Option[String]]("none-option-string").isEmpty shouldBe true
     conf[Option[Int]]("some-option-int").value shouldBe 1
-    conf[Option[Int]]("none-option-int") shouldBe 'empty
+    conf[Option[Int]]("none-option-int").isEmpty shouldBe true
   }
 
   it should "support optional configuration" in {
@@ -161,7 +161,7 @@ class ConfigurationLikeTest extends UnitSpec with CaptureSystemStreams with Opti
     val conf = Configuration(configPath)
     conf[String]("config-name") shouldBe "a-name"
     conf[Boolean]("config-status") shouldBe false
-    conf.get[String]("config-does-not-exist") shouldBe 'empty
+    conf.get[String]("config-does-not-exist").isEmpty shouldBe true
 
     conf.requestedKeys should contain theSameElementsInOrderAs Seq("config-does-not-exist", "config-name", "config-status")
   }

--- a/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
@@ -170,7 +170,7 @@ class DelimitedDataParserTest extends UnitSpec {
       |foo,bar,splat
       |one,uno,1
       |two,dos ,2
-    """.stripMargin.trim.lines.filter(_.nonEmpty).toIndexedSeq
+    """.stripMargin.trim.linesIterator.filter(_.nonEmpty).toIndexedSeq
     val parser = csv(data)
     var rows = 0
     parser.foreach { row =>

--- a/src/test/scala/com/fulcrumgenomics/commons/util/LoggerTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/LoggerTest.scala
@@ -103,7 +103,7 @@ class LoggerTest extends UnitSpec with LazyLogging with BeforeAndAfterEach with 
     val pw = new PrintStream(stream)
     logger.out = Some(pw)
     logger.debug("Arg!")
-    stream.toString shouldBe 'empty
+    stream.toString.isEmpty shouldBe true
   }
 
   it should "have a logger when mixing in LazyLogging" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/util/NumericCounterTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/NumericCounterTest.scala
@@ -25,6 +25,8 @@
 
 package com.fulcrumgenomics.commons.util
 
+import com.fulcrumgenomics.commons.CommonsDef._
+
 /**
   * Tests for NumericCounter.
   */

--- a/src/test/scala/com/fulcrumgenomics/commons/util/NumericCounterTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/NumericCounterTest.scala
@@ -32,7 +32,7 @@ class NumericCounterTest extends UnitSpec {
 
   "NumericCounter" should "operate on Ints" in {
     val counter = new NumericCounter[Int]()
-    Stream.range(1, 10, 1).foreach { i => counter.count(i, 1) }
+    Range(1, 10, 1).foreach { i => counter.count(i, 1) }
     counter.count(1)
     counter.iterator.sliding(2).foreach { case Seq(lower, upper) => lower should be < upper }
     counter.mean() shouldBe 4.6 +- 0.0001
@@ -45,7 +45,7 @@ class NumericCounterTest extends UnitSpec {
 
   it should "operate on Doubles" in {
     val counter = new NumericCounter[Double]()
-    Stream.range(1, 10, 1).foreach { i => counter.count(i / 10.0, 1) }
+    Range(1, 10, 1).foreach { i => counter.count(i / 10.0, 1) }
     counter.count(1 / 10.0)
     counter.iterator.sliding(2).foreach { case Seq(lower, upper) => lower should be < upper }
     counter.mean() shouldBe 0.46 +- 0.0001

--- a/src/test/scala/com/fulcrumgenomics/commons/util/ThreadsTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/ThreadsTest.scala
@@ -26,6 +26,7 @@
 package com.fulcrumgenomics.commons.util
 
 import com.fulcrumgenomics.commons.CommonsDef.seqToParSupport
+
 /**
   * Tests for Threads
   */
@@ -33,7 +34,7 @@ class ThreadsTest extends UnitSpec {
 
   "Threads.IterableThreadLocal" should "create thread local objects with a factory for initial values" in {
     val threadLocalValues = Iterator.iterate(1)(i => i + 1)
-    val threadLocal       = new Threads.IterableThreadLocal[Int](() => threadLocalValues.next())
+    val threadLocal       = new Threads.IterableThreadLocal[Int](() => threadLocalValues.synchronized(threadLocalValues.next()))
     val outputValues      = Seq(1, 2, 3, 4, 5)
       .parWith(parallelism = 2)
       .map(_ + threadLocal.get())


### PR DESCRIPTION
In the end I think it's easier to stop using symbols and instead just hit the methods directly, i.e. `foo shouldBe 'success` => `foo.isSuccess shouldBe true`.  I tried using some constant symbols, but it's ugly.  If you want to use, e.g. `Success` then that conflicts with the subclass of `Try` and causes other issues.