### PR TITLE
Move automatic gzip detection from fgbio to commons.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -47,6 +47,7 @@ trait IoUtil {
 
   /** How large a buffer should be used when buffering operations. */
   def bufferSize: Int = 32 * 1024
+  /** The level compression to use when writing compressed output. */
   def compressionLevel: Int = 5
 
   /** Creates a new InputStream to read from the supplied path. Automatically handles gzipped files. */

--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -47,7 +47,7 @@ trait IoUtil {
 
   /** How large a buffer should be used when buffering operations. */
   def bufferSize: Int = 32 * 1024
-  /** The level compression to use when writing compressed output. */
+  /** The level of compression to use when writing compressed output. */
   def compressionLevel: Int = 5
 
   /** Creates a new InputStream to read from the supplied path. Automatically handles gzipped files. */

--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -208,7 +208,7 @@ class IoTest extends UnitSpec {
     reader.close()
   }
 
-  "Io.toOutputStream" should "round trip data to a gzipped file if it ends with .gz" in {
+  it should "round trip data to a gzipped file if it ends with .gz" in {
     val text = "This is a stupid little text fragment for compression. Yay compression!"
     val in   = Seq(text, text, text)
     val f = Io.makeTempFile("test", ".gz")

--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -23,8 +23,9 @@
  */
 package com.fulcrumgenomics.commons.io
 
-import java.io.{BufferedOutputStream, FileOutputStream}
+import java.io.{BufferedOutputStream, BufferedReader, FileInputStream, FileOutputStream, InputStreamReader}
 import java.nio.file.{Files, Path, Paths}
+import java.util.zip.GZIPInputStream
 
 import com.fulcrumgenomics.commons.util.UnitSpec
 
@@ -193,4 +194,27 @@ class IoTest extends UnitSpec {
     val actual = Io.readBytesFromResource("/com/fulcrumgenomics/commons/io/to-bytes-from-resource-test.bin")
     actual shouldBe expected
   }
+
+  "Io.toInputStream" should "open a file for gzip writing if it ends with .gz" in {
+    val text = "This is a stupid little text fragment for compression. Yay compression!"
+    val in   = Seq(text, text, text)
+    val f = Io.makeTempFile("test", ".gz")
+    Io.writeLines(f, in)
+
+    // Manually read it back as gzipped data
+    val reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(f.toFile))))
+    val out = Seq(reader.readLine(), reader.readLine(), reader.readLine())
+    out shouldBe in
+    reader.close()
+  }
+
+  "Io.toOutputStream" should "round trip data to a gzipped file if it ends with .gz" in {
+    val text = "This is a stupid little text fragment for compression. Yay compression!"
+    val in   = Seq(text, text, text)
+    val f = Io.makeTempFile("test", ".gz")
+    Io.writeLines(f, in)
+    val out = Io.readLines(f).toSeq
+    out shouldBe in
+  }
+
 }

--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -216,5 +216,4 @@ class IoTest extends UnitSpec {
     val out = Io.readLines(f).toSeq
     out shouldBe in
   }
-
 }

--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -198,7 +198,7 @@ class IoTest extends UnitSpec {
   "Io.toInputStream" should "open a file for gzip writing if it ends with .gz" in {
     val text = "This is a stupid little text fragment for compression. Yay compression!"
     val in   = Seq(text, text, text)
-    val f = Io.makeTempFile("test", ".gz")
+    val f    = Io.makeTempFile("test", ".gz")
     Io.writeLines(f, in)
 
     // Manually read it back as gzipped data
@@ -211,7 +211,7 @@ class IoTest extends UnitSpec {
   "Io.toOutputStream" should "round trip data to a gzipped file if it ends with .gz" in {
     val text = "This is a stupid little text fragment for compression. Yay compression!"
     val in   = Seq(text, text, text)
-    val f = Io.makeTempFile("test", ".gz")
+    val f    = Io.makeTempFile("test", ".gz")
     Io.writeLines(f, in)
     val out = Io.readLines(f).toSeq
     out shouldBe in


### PR DESCRIPTION
I've migrated the gzip auto detection functionality and tests. I left the bgzip outputStream detection in fgbio because it depends on htsjdk which is not in commons. 