### PR TITLE
Allow IoUtil trait's compressionLevel var to be settable by extending classes

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -35,7 +35,9 @@ import scala.io.Source
 /**
 * Singleton object to provide access to Io utility methods.
 */
-object Io extends IoUtil
+object Io extends IoUtil() {
+  override var compressionLevel: Int = 5
+}
 
 /**
  * Trait that can be mixed in to make an Io utility object, and can be re-used elsewhere.
@@ -46,7 +48,7 @@ trait IoUtil {
   val DevNull: Path = PathUtil.pathTo("/dev/null")
 
   /** The level of compression to use when writing compressed output. */
-  var compressionLevel: Int = 5
+  var compressionLevel: Int
   /** How large a buffer should be used when buffering operations. */
   def bufferSize: Int = 32 * 1024
 

--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -36,7 +36,7 @@ import scala.io.Source
 * Singleton object to provide access to Io utility methods.
 */
 object Io extends IoUtil() {
-  override var compressionLevel: Int = 5
+  override def compressionLevel: Int = 5
 }
 
 /**
@@ -48,7 +48,8 @@ trait IoUtil {
   val DevNull: Path = PathUtil.pathTo("/dev/null")
 
   /** The level of compression to use when writing compressed output. */
-  var compressionLevel: Int
+  // var compressionLevel: Int
+  def compressionLevel: Int
   /** How large a buffer should be used when buffering operations. */
   def bufferSize: Int = 32 * 1024
 

--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -45,10 +45,10 @@ trait IoUtil {
   val StdOut: Path = PathUtil.pathTo("/dev/stdout")
   val DevNull: Path = PathUtil.pathTo("/dev/null")
 
+  /** The level of compression to use when writing compressed output. */
+  var compressionLevel: Int = 5
   /** How large a buffer should be used when buffering operations. */
   def bufferSize: Int = 32 * 1024
-  /** The level of compression to use when writing compressed output. */
-  def compressionLevel: Int = 5
 
   /** Creates a new InputStream to read from the supplied path. Automatically handles gzipped files. */
   def toInputStream(path: Path) : InputStream = {

--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -54,7 +54,7 @@ class IoTest extends UnitSpec {
   }
 
   /** Impl of IoUtil to test that compressionLevel can be overridden and set */
-  class FakeIo(override var compressionLevel: Int = 5, override val bufferSize: Int = 128*1024) extends IoUtil {}
+  class FakeIo(var compressionLevel: Int = 5, override val bufferSize: Int = 128*1024) extends IoUtil {}
   object FakeIo extends FakeIo(compressionLevel=5, bufferSize=128*1024)
 
   "Io.assertReadable" should "not throw an exception for extent files" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -223,6 +223,6 @@ class IoTest extends UnitSpec {
   
   "IoUtil.compressionLevel" should "be settable" in {
     FakeIo.compressionLevel = 6
-    FakeIo.compressionLevel shouldEqual 6
+    FakeIo.compressionLevel shouldBe 6
   }
 }

--- a/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/IoTest.scala
@@ -53,6 +53,10 @@ class IoTest extends UnitSpec {
     path
   }
 
+  /** Impl of IoUtil to test that compressionLevel can be overridden and set */
+  class FakeIo(override var compressionLevel: Int = 5, override val bufferSize: Int = 128*1024) extends IoUtil {}
+  object FakeIo extends FakeIo(compressionLevel=5, bufferSize=128*1024)
+
   "Io.assertReadable" should "not throw an exception for extent files" in {
     val f1 = tmpfile(); val f2 = tmpfile(); val f3 = tmpfile()
     Io.assertReadable(f1)
@@ -215,5 +219,10 @@ class IoTest extends UnitSpec {
     Io.writeLines(f, in)
     val out = Io.readLines(f).toSeq
     out shouldBe in
+  }
+  
+  "IoUtil.compressionLevel" should "be settable" in {
+    FakeIo.compressionLevel = 6
+    FakeIo.compressionLevel shouldEqual 6
   }
 }


### PR DESCRIPTION
When compressionLevel was a method, it could not be set, which is needed in fgbio on the singleton Io object in FgBioMain. This should fix that now by requiring anything that extends IoUtil to provide a default for the compressionLevel.