### PR TITLE
row.get returns Some(" ") instead of returning None when allowMissingColumn flag is set

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -74,9 +74,9 @@ class Row private[util] (private val headerIndices: Map[String,Int], private val
     * `allowMissingColumn` is true, then None is returned if the given column name is not present. */
   def get[A](column: String, allowMissingColumn: Boolean = false)(implicit tag: ru.TypeTag[A]): Option[A] =
     (headerIndices.get(column), allowMissingColumn) match {
+      case (Some(idx), _) => get[A](idx)      
       case (None, true)   => None
       case (None, false)  => throw new NoSuchElementException(column)
-      case (Some(idx), _) => get[A](idx)
     }
 }
 

--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -73,7 +73,7 @@ class Row private[util] (private val headerIndices: Map[String,Int], private val
   /** Gets a value from the specified column. If the value is null or empty returns None.  If
     * `allowMissingColumn` is true, then None is returned if the given column name is not present. */
   def get[A](column: String, allowMissingColumn: Boolean = false)(implicit tag: ru.TypeTag[A]): Option[A] =
-    if (allowMissingColumn) headerIndices.get(column).map(apply[A]) else get(headerIndices(column))
+    if( allowMissingColumn && ! headerIndices.contains(column)) None else get(headerIndices(column))
 }
 
 

--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -73,7 +73,11 @@ class Row private[util] (private val headerIndices: Map[String,Int], private val
   /** Gets a value from the specified column. If the value is null or empty returns None.  If
     * `allowMissingColumn` is true, then None is returned if the given column name is not present. */
   def get[A](column: String, allowMissingColumn: Boolean = false)(implicit tag: ru.TypeTag[A]): Option[A] =
-    if (allowMissingColumn && ! headerIndices.contains(column)) None else get(headerIndices(column))
+    (headerIndices.get(column), allowMissingColumn) match {
+      case (None, true)   => None
+      case (None, false)  => throw new NoSuchElementException(column)
+      case (Some(idx), _) => get[A](idx)
+    }
 }
 
 

--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -73,7 +73,7 @@ class Row private[util] (private val headerIndices: Map[String,Int], private val
   /** Gets a value from the specified column. If the value is null or empty returns None.  If
     * `allowMissingColumn` is true, then None is returned if the given column name is not present. */
   def get[A](column: String, allowMissingColumn: Boolean = false)(implicit tag: ru.TypeTag[A]): Option[A] =
-    if( allowMissingColumn && ! headerIndices.contains(column)) None else get(headerIndices(column))
+    if (allowMissingColumn && ! headerIndices.contains(column)) None else get(headerIndices(column))
 }
 
 

--- a/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
@@ -143,7 +143,7 @@ class DelimitedDataParserTest extends UnitSpec {
     row1[Int]("b") shouldBe 1
     row2.get[String]("a") shouldBe None
     row2.get[String]("b") shouldBe None
-    row2.get[String]("c") shouldBe None
+    row2.get[String]("c", allowMissingColumn=true) shouldBe None
   }
 
   it should "read present and absent values correctly using get()" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
@@ -211,7 +211,7 @@ class DelimitedDataParserTest extends UnitSpec {
     an[Exception] shouldBe thrownBy { row.get[Int]("d", allowMissingColumn=false) }
   }
 
-  it should "test empty fields returning None when allowMissingColumn is true" in {
+  it should "return None for missing values even with allowMissingColumn is true" in {
     val parser = csv(Seq("a,b,c", "1,2,"))
     val row = parser.next()
 

--- a/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
@@ -143,7 +143,7 @@ class DelimitedDataParserTest extends UnitSpec {
     row1[Int]("b") shouldBe 1
     row2.get[String]("a") shouldBe None
     row2.get[String]("b") shouldBe None
-    row2.get[String]("c", allowMissingColumn=true) shouldBe None
+    row2.get[String]("c") shouldBe None
   }
 
   it should "read present and absent values correctly using get()" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
@@ -210,4 +210,12 @@ class DelimitedDataParserTest extends UnitSpec {
     row.get[Int]("d", allowMissingColumn=true) shouldBe None
     an[Exception] shouldBe thrownBy { row.get[Int]("d", allowMissingColumn=false) }
   }
+
+  it should "test empty fields returning None when allowMissingColumn is true" in {
+    val parser = csv(Seq("a,b,c", "1,2,"))
+    val row = parser.next()
+
+    row.get[String]("c", allowMissingColumn=true) shouldBe None
+  }
+
 }


### PR DESCRIPTION
row.get returns `Some(" ")` instead of returning `None` when `allowMissingColumn` flag is set to true and the field is empty. None is correctly returned when `allowMissingColumn` is not set.
@clintval 