### PR TITLE
[bugfix] Sanitize file name now truncates files to avoid filesystem errors on names larger than 255 characters.

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
@@ -28,6 +28,9 @@ import java.nio.file.{Path, Paths}
 
 /** Provides utility methods for creating and manipulating Path objects and path-like Strings. */
 object PathUtil {
+  @Deprecated("Use `IllegalCharacters`")
+  def illegalCharacters: String = IllegalCharacters
+
   val MaxFileNameSize: Int = 254
   val IllegalCharacters: String = "[!\"#$%&'()*/:;<=>?@\\^`{|}~] "
 

--- a/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
@@ -28,8 +28,8 @@ import java.nio.file.{Path, Paths}
 
 /** Provides utility methods for creating and manipulating Path objects and path-like Strings. */
 object PathUtil {
-  val maxFileNameSize: Int = 254
-  val illegalCharacters: String = "[!\"#$%&'()*/:;<=>?@\\^`{|}~] "
+  val MaxFileNameSize: Int = 254
+  val IllegalCharacters: String = "[!\"#$%&'()*/:;<=>?@\\^`{|}~] "
 
   /** Resolves a path from a String, and then makes the path absolute. Prefer this to PathUtil.pathTo elsewhere. */
   def pathTo(first: String, more: String*): Path = Paths.get(first, more:_*).toAbsolutePath.normalize
@@ -38,19 +38,19 @@ object PathUtil {
     * truncate the file name to be, at maximum, 255 characters.
     *
     * @param fileName the string that is to be used as a filename
-    * @param illegalCharacters the set of characters to be replaced if found, defaults to [[illegalCharacters]]
+    * @param illegalCharacters the set of characters to be replaced if found, defaults to [[IllegalCharacters]]
     * @param replacement an optional replacement character, defaulting to '_'; if None characters are just removed
     * @return the filename without illegal characters
     */
   def sanitizeFileName(fileName: String,
-                       illegalCharacters: String = PathUtil.illegalCharacters,
+                       illegalCharacters: String = PathUtil.IllegalCharacters,
                        replacement: Option[Char] = Some('_'),
                        maxFileNameSize: Option[Int] = Some(MaxFileNameSize)): String = {
     val sanitizedFileName = replacement match {
       case None    => fileName.filter(c => !illegalCharacters.contains(c))
       case Some(r) => fileName.map(c => if (illegalCharacters.contains(c)) r else c)
     }
-    sanitizedFileName.substring(0, Math.min(sanitizedFileName.length, maxFileNameSize))
+    sanitizedFileName.substring(0, Math.min(sanitizedFileName.length, MaxFileNameSize))
   }
 
   /** Replaces the extension on an existing path. */

--- a/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
@@ -46,7 +46,7 @@ object PathUtil {
                        illegalCharacters: String = PathUtil.illegalCharacters,
                        replacement: Option[Char] = Some('_')): String = {
     val sanitizedFileName = replacement match {
-      case None => fileName.filter(c => !illegalCharacters.contains(c))
+      case None    => fileName.filter(c => !illegalCharacters.contains(c))
       case Some(r) => fileName.map(c => if (illegalCharacters.contains(c)) r else c)
     }
     sanitizedFileName.substring(0, Math.min(sanitizedFileName.length, maxFileNameSize))

--- a/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
@@ -44,7 +44,8 @@ object PathUtil {
     */
   def sanitizeFileName(fileName: String,
                        illegalCharacters: String = PathUtil.illegalCharacters,
-                       replacement: Option[Char] = Some('_')): String = {
+                       replacement: Option[Char] = Some('_'),
+                       maxFileNameSize: Option[Int] = Some(MaxFileNameSize)): String = {
     val sanitizedFileName = replacement match {
       case None    => fileName.filter(c => !illegalCharacters.contains(c))
       case Some(r) => fileName.map(c => if (illegalCharacters.contains(c)) r else c)

--- a/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
@@ -28,12 +28,14 @@ import java.nio.file.{Path, Paths}
 
 /** Provides utility methods for creating and manipulating Path objects and path-like Strings. */
 object PathUtil {
+  val maxFileNameSize: Int = 254
   val illegalCharacters: String = "[!\"#$%&'()*/:;<=>?@\\^`{|}~] "
 
   /** Resolves a path from a String, and then makes the path absolute. Prefer this to PathUtil.pathTo elsewhere. */
   def pathTo(first: String, more: String*): Path = Paths.get(first, more:_*).toAbsolutePath.normalize
 
-  /** Replaces a set of illegal characters within a String that is to be used as a filename.
+  /** Replaces a set of illegal characters within a String that is to be used as a filename. This will also
+    * truncate the file name to be, at maximum, 255 characters.
     *
     * @param fileName the string that is to be used as a filename
     * @param illegalCharacters the set of characters to be replaced if found, defaults to [[illegalCharacters]]
@@ -42,9 +44,12 @@ object PathUtil {
     */
   def sanitizeFileName(fileName: String,
                        illegalCharacters: String = PathUtil.illegalCharacters,
-                       replacement: Option[Char] = Some('_')): String = replacement match {
-    case None    => fileName.filter(c => !illegalCharacters.contains(c))
-    case Some(r) => fileName.map(c => if (illegalCharacters.contains(c)) r else c)
+                       replacement: Option[Char] = Some('_')): String = {
+    val sanitizedFileName = replacement match {
+      case None => fileName.filter(c => !illegalCharacters.contains(c))
+      case Some(r) => fileName.map(c => if (illegalCharacters.contains(c)) r else c)
+    }
+    sanitizedFileName.substring(0, Math.min(fileName.length, maxFileNameSize))
   }
 
   /** Replaces the extension on an existing path. */

--- a/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
@@ -28,7 +28,7 @@ import java.nio.file.{Path, Paths}
 
 /** Provides utility methods for creating and manipulating Path objects and path-like Strings. */
 object PathUtil {
-  @Deprecated("Use `IllegalCharacters`")
+  @deprecated("Use `IllegalCharacters`")
   def illegalCharacters: String = IllegalCharacters
 
   val MaxFileNameSize: Int = 254

--- a/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
@@ -49,7 +49,7 @@ object PathUtil {
       case None => fileName.filter(c => !illegalCharacters.contains(c))
       case Some(r) => fileName.map(c => if (illegalCharacters.contains(c)) r else c)
     }
-    sanitizedFileName.substring(0, Math.min(fileName.length, maxFileNameSize))
+    sanitizedFileName.substring(0, Math.min(sanitizedFileName.length, maxFileNameSize))
   }
 
   /** Replaces the extension on an existing path. */

--- a/src/test/scala/com/fulcrumgenomics/commons/io/PathUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/PathUtilTest.scala
@@ -71,7 +71,7 @@ class PathUtilTest extends UnitSpec {
     PathUtil.sanitizeFileName("A_B!C", replacement = Some('X')) should be("A_BXC")
     PathUtil.sanitizeFileName("A B\nC") should be("A_B\nC")
     PathUtil.sanitizeFileName("A1B2C", replacement = Some('_')) should be("A1B2C")
-    PathUtil.sanitizeFileName("A_B C", illegalCharacters = s"${PathUtil.illegalCharacters}ABC", replacement = Some('_')) should be("_____")
+    PathUtil.sanitizeFileName("A_B C", illegalCharacters = s"${PathUtil.IllegalCharacters}ABC", replacement = Some('_')) should be("_____")
     PathUtil.sanitizeFileName("A1B2C", replacement = None) should be("A1B2C")
     PathUtil.sanitizeFileName("A_B!C", replacement = None) should be("A_BC")
   }
@@ -83,18 +83,8 @@ class PathUtilTest extends UnitSpec {
   }
 
   it should "truncate file names longer than 255 characters" in {
-    PathUtil.sanitizeFileName("thisisthemostridiculouslylongfilenameandforsomereasonwestillneedtoh" +
-      "aveasanitizemethodthatensuresthatnoonecreatesafilenamethatisaslongasthisonewhichiskindofsilywhenyou" +
-      "thinkaboutitsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihavenoidea")should be("this" +
-      "isthemostridiculouslylongfilenameandforsomereasonwestillneedtohaveasanitizemethodthatensuresthatnoonecreatesa" +
-      "filenamethatisaslongasthisonewhichiskindofsilywhenyouthinkaboutitsincewhywouldyoueverreallyneedafilenamethat" +
-      "isaslongasthisonehonestlyihavenoi")
-    PathUtil.sanitizeFileName("!!thisisthemostridiculouslylongfilenameandforsomereasonwestillneedtoh" +
-      "aveasanitizemethodthatensuresthatnoonecreatesafilenamethatisaslongasthisonewhichiskindofsilywhenyou" +
-      "thinkaboutitsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihavenoidea",
-      replacement = Some('X')) should be("XXthisisthemostridiculouslylongfilenameandforsomereasonwestillneedtohavea" +
-      "sanitizemethodthatensuresthatnoonecreatesafilenamethatisaslongasthisonewhichiskindofsilywhenyouthinkabout" +
-      "itsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihaven")
+    PathUtil.sanitizeFileName("!" * (PathUtil.MaxFileNameSize + 10)) shouldBe "_" * PathUtil.MaxFileNameSize
+    PathUtil.sanitizeFileName("!" * (PathUtil.MaxFileNameSize + 10), replacement = Some('X')) shouldBe "X" * PathUtil.MaxFileNameSize
   }
 
   "PathUtil.pathTo" should "resolve absolute paths just like Paths.get does" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/io/PathUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/PathUtilTest.scala
@@ -88,13 +88,13 @@ class PathUtilTest extends UnitSpec {
       "thinkaboutitsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihavenoidea")should be("this" +
       "isthemostridiculouslylongfilenameandforsomereasonwestillneedtohaveasanitizemethodthatensuresthatnoonecreatesa" +
       "filenamethatisaslongasthisonewhichiskindofsilywhenyouthinkaboutitsincewhywouldyoueverreallyneedafilenamethat" +
-      "isaslongasthisonehonestlyihavenoid")
+      "isaslongasthisonehonestlyihavenoi")
     PathUtil.sanitizeFileName("!!thisisthemostridiculouslylongfilenameandforsomereasonwestillneedtoh" +
       "aveasanitizemethodthatensuresthatnoonecreatesafilenamethatisaslongasthisonewhichiskindofsilywhenyou" +
       "thinkaboutitsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihavenoidea",
       replacement = Some('X')) should be("XXthisisthemostridiculouslylongfilenameandforsomereasonwestillneedtohavea" +
       "sanitizemethodthatensuresthatnoonecreatesafilenamethatisaslongasthisonewhichiskindofsilywhenyouthinkabout" +
-      "itsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihaveno")
+      "itsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihaven")
   }
 
   "PathUtil.pathTo" should "resolve absolute paths just like Paths.get does" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/io/PathUtilTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/io/PathUtilTest.scala
@@ -82,6 +82,21 @@ class PathUtilTest extends UnitSpec {
     PathUtil.replaceExtension(PathUtil.pathTo("/Foo/bar/splat.bam"), ".not_yo_mama") should be (PathUtil.pathTo("/Foo/bar/splat.not_yo_mama"))
   }
 
+  it should "truncate file names longer than 255 characters" in {
+    PathUtil.sanitizeFileName("thisisthemostridiculouslylongfilenameandforsomereasonwestillneedtoh" +
+      "aveasanitizemethodthatensuresthatnoonecreatesafilenamethatisaslongasthisonewhichiskindofsilywhenyou" +
+      "thinkaboutitsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihavenoidea")should be("this" +
+      "isthemostridiculouslylongfilenameandforsomereasonwestillneedtohaveasanitizemethodthatensuresthatnoonecreatesa" +
+      "filenamethatisaslongasthisonewhichiskindofsilywhenyouthinkaboutitsincewhywouldyoueverreallyneedafilenamethat" +
+      "isaslongasthisonehonestlyihavenoid")
+    PathUtil.sanitizeFileName("!!thisisthemostridiculouslylongfilenameandforsomereasonwestillneedtoh" +
+      "aveasanitizemethodthatensuresthatnoonecreatesafilenamethatisaslongasthisonewhichiskindofsilywhenyou" +
+      "thinkaboutitsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihavenoidea",
+      replacement = Some('X')) should be("XXthisisthemostridiculouslylongfilenameandforsomereasonwestillneedtohavea" +
+      "sanitizemethodthatensuresthatnoonecreatesafilenamethatisaslongasthisonewhichiskindofsilywhenyouthinkabout" +
+      "itsincewhywouldyoueverreallyneedafilenamethatisaslongasthisonehonestlyihaveno")
+  }
+
   "PathUtil.pathTo" should "resolve absolute paths just like Paths.get does" in {
     PathUtil.pathTo("/foo")         shouldBe Paths.get("/foo")
     PathUtil.pathTo("/foo/bar")     shouldBe Paths.get("/foo/bar")


### PR DESCRIPTION
Most modern day file systems (ext4, ntfs, xfs, apfs, etc) limit file name size to 255 characters. This PR will ensure that any filename handed back from `sanitizeFileName` will be, at maxiumum, 255 characters.