### PR TITLE
Use thread-safe DateTimeFormatter in log emissions

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/util/Logger.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/Logger.scala
@@ -24,8 +24,8 @@
 package com.fulcrumgenomics.commons.util
 
 import java.io.{PrintStream, PrintWriter, StringWriter}
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 import scala.collection.compat._
 
@@ -45,14 +45,15 @@ object Logger {
  */
 class Logger(clazz : Class[_]) {
   private val name = Logger.sanitizeSimpleClassName(clazz.getSimpleName)
-  private val fmt = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss")
+  private val fmt  = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")
   var out: Option[PrintStream] = None
 
   /** Checks to see if a message should be emitted given the current log level, and then emits atomically. */
   protected def emit(l: LogLevel, parts: IterableOnce[Any]) : Unit = {
     if (l.compareTo(Logger.level) >= 0) {
       val builder = new StringBuilder(256)
-      builder.append("[").append(fmt.format(new Date())).append(" | ").append(name).append(" | ").append(l.toString).append("] ")
+      val now     = fmt.format(LocalDateTime.now())
+      builder.append("[").append(now).append(" | ").append(name).append(" | ").append(l.toString).append("] ")
       parts.iterator.foreach(part => builder.append(part))
       this.out match {
         case Some(o) => o.println(builder.toString())

--- a/src/main/scala/com/fulcrumgenomics/commons/util/Logger.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/Logger.scala
@@ -41,7 +41,7 @@ object Logger {
 }
 
 /**
- * Very simple logging class that supports logging at multiple levels.
+ * Very simple thread-safe logging class that supports logging at multiple levels.
  */
 class Logger(clazz : Class[_]) {
   private val name = Logger.sanitizeSimpleClassName(clazz.getSimpleName)


### PR DESCRIPTION
Unfortunately `SimpleDateFormat` is not thread-safe and must be synchronized. Instead of synchronizing access to the class, I replaced it with the Java 8 `DateTimeFormatter` which is thread-safe by default. I believe this will make synchronous access to these loggers possible. Snippet from the unit tests show no functional change:

```console
[2021/01/03 17:19:15 | DelimitedDataParser | Error] Line has incorrect number of fields. Header length is 3, row length is 4
[2021/01/03 17:19:15 | DelimitedDataParser | Error] Headers: one,two,three
[2021/01/03 17:19:15 | DelimitedDataParser | Error] Line: one,two,three,four
[2021/01/03 17:19:15 | DelimitedDataParser | Error] Line has incorrect number of fields. Header length is 3, row length is 2
[2021/01/03 17:19:15 | DelimitedDataParser | Error] Headers: one,two,three
[2021/01/03 17:19:15 | DelimitedDataParser | Error] Line: one,two
```