### PR TITLE
Make BiMap a better all around Scala Map collection

### DIFF
--- a/src/main/scala-2.12-/com/fulcrumgenomics/commons/Compat.scala
+++ b/src/main/scala-2.12-/com/fulcrumgenomics/commons/Compat.scala
@@ -8,6 +8,9 @@ private[commons] trait Compat {
     * 2.13 and replaced with the newly defined ConstantAnnotation.. */
   type ConstantAnnotation = scala.annotation.ClassfileAnnotation
 
+  /** A mutable grower for building collections. In Scala 2.13 this class was renamed to `GrowableBuilder`. */
+  type MutableGrowableBuilder[Elem, To <: scala.collection.generic.Growable[Elem]] = scala.collection.mutable.GrowingBuilder[Elem, To]
+
   /** For basic views in 2.12 we use the old scala.collection.IterableView which has disappeared in 2.13 to
     * be replaced by View. */
   type View[+A] = scala.collection.IterableView[A, Iterable[A]]

--- a/src/main/scala-2.13+/com/fulcrumgenomics/commons/Compat.scala
+++ b/src/main/scala-2.13+/com/fulcrumgenomics/commons/Compat.scala
@@ -1,9 +1,14 @@
 package com.fulcrumgenomics.commons
 
+import scala.collection.mutable
+
 /** Trait that includes types used for cross-building compatibility; scala 2.13 version. */
 private[commons] trait Compat {
   /** For annotations available at runtime in 2.13 we use ConstantAnnotation. */
   type ConstantAnnotation = scala.annotation.ConstantAnnotation
+
+  /** A mutable grower for building collections. In Scala 2.12 this class was once called to `GrowingBuilder`. */
+  type MutableGrowableBuilder[Elem, To <: mutable.Growable[Elem]] = scala.collection.mutable.GrowableBuilder[Elem, To]
 
   /** For basic views we use the new scala.collection.View. */
   type View[+A] = scala.collection.View[A]

--- a/src/main/scala/com/fulcrumgenomics/commons/collection/BiMap.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/collection/BiMap.scala
@@ -24,22 +24,29 @@
 
 package com.fulcrumgenomics.commons.collection
 
-import scala.collection.mutable
+import com.fulcrumgenomics.commons.CommonsDef._
 
-/** An iterable bi-Directional map.  There is a 1:1 mapping between keys and values.
- *
- * @tparam K the key type.
- * @tparam V the value type.
- */
-class BiMap[K, V]() extends Iterable[(K, V)] {
+import scala.collection.compat._
+import scala.collection.{StrictOptimizedIterableOps, StrictOptimizedMapOps, mutable}
+
+/** A iterable bi-Directional map. There is a 1:1 mapping between keys and values. */
+class BiMap[K, V]() extends mutable.Map[K, V]
+  with mutable.MapOps[K, V, mutable.Map, BiMap[K, V]]
+  with StrictOptimizedMapOps[K, V, mutable.Map, BiMap[K, V]]
+  with StrictOptimizedIterableOps[(K, V), mutable.Iterable, BiMap[K, V]]  {
   private val forward = new mutable.HashMap[K, V]()
   private val reverse = new mutable.HashMap[V, K]()
 
-  /** Adds a tuple to the map.
-   *
-   * @param key the key.
-   * @param value the value.
-   */
+  /** The class name of this map. */
+  override def className = "BiMap"
+
+  /** Adds a key-value pair to the map. */
+  override def addOne(elem: (K, V)): this.type = {
+    add(elem._1, elem._2)
+    this
+  }
+
+  /** Adds a key-value pair to the map. */
   def add(key: K, value: V): Unit = {
     removeKey(key)
     removeValue(value)
@@ -47,39 +54,47 @@ class BiMap[K, V]() extends Iterable[(K, V)] {
     reverse.put(value, key)
   }
 
-  /** Get a key associated with the given value.
-   *
-   * @param value the value to lookup.
-   * @return the key associated with the value, None if not found.
-   */
-  def keyFor(value: V): Option[K] = reverse.get(value)
+  /** Clear this map. */
+  override def clear(): Unit = {
+    forward.clear()
+    reverse.clear()
+  }
 
-  /** Get a value associated with a given key.
-   *
-   * @param key the key to lookup.
-   * @return the value associated with the key, None if not found.
-   */
-  def valueFor(key: K): Option[V] = forward.get(key)
+  /** Concatenate this map with another set of key-value pairs. */ // Implemented to further refine the return type
+  override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]): BiMap[K, V2] = {
+    strictOptimizedConcat(suffix, BiMap.newBuilder)
+  }
 
-  /** Checks if the map contains the given key.
-   *
-   * @param key the key to check.
-   * @return true if the key is in the map, false otherwise.
-   */
+  /** Checks if the map contains the given key. */
   def containsKey(key: K): Boolean = forward.contains(key)
 
-  /** Checks if the map contains the given value.s
-   *
-   * @param value the value to check.
-   * @return true if the value is in the map, false otherwise.
-   */
+  /** Checks if the map contains the given value. */
   def containsValue(value: V): Boolean = reverse.contains(value)
 
-  /** Remove a key and associated value from the map.
-   *
-   * @param key the key to remove.
-   * @return true if the key and associated value were removed successfully, false otherwise.
-   */
+  /** An empty [[BiMap]]. */ // Implemented to further refine the return type
+  override def empty: BiMap[K, V] = new BiMap[K, V]
+
+  /** Transform this map and flatten in one level with a function on each key-value pair. */
+  override def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]): BiMap[K2, V2] = {
+    strictOptimizedFlatMap(BiMap.newBuilder, f)
+  }
+
+  /** Get a value associated with a given key. */
+  override def get(key: K): Option[V] = forward.get(key)
+
+  /** An iterator of key-value pairs contained in this map. */
+  def iterator: Iterator[(K, V)] = forward.iterator
+
+  /** Transform this map with a function on each key-value pair. */
+  override def map[K2, V2](f: ((K, V)) => (K2, V2)): BiMap[K2, V2] = strictOptimizedMap(BiMap.newBuilder, f)
+
+  /** Get a key associated with the given value. */
+  def keyFor(value: V): Option[K] = reverse.get(value)
+
+  /** The keys in this map. */
+  override def keys: Iterable[K] = forward.keys
+
+  /** Remove a key and its associated value from the map. */
   def removeKey(key: K): Boolean = {
     valueFor(key) match {
       case Some(value) =>
@@ -90,11 +105,7 @@ class BiMap[K, V]() extends Iterable[(K, V)] {
     }
   }
 
-  /** Remove a value and associated key from the map.
-    *
-    * @param value the value to remove.
-    * @return true if the value and associated key were removed successfully, false otherwise.
-    */
+  /** Remove a value and its associated key from the map. */
   def removeValue(value: V): Boolean = {
     keyFor(value) match {
       case Some(key) =>
@@ -105,29 +116,56 @@ class BiMap[K, V]() extends Iterable[(K, V)] {
     }
   }
 
-  /**
-   *
-   * @return the keys in this map.
-   */
-  def keys: Iterable[K] = forward.keys
-
-  /**
-   *
-   * @return the values in this map.
-   */
-  def values: Iterable[V] = reverse.keys
-
-  /**
-   *
-   * @return the number of tuples in this map.
-   */
+  /** The number of key-value pairs in this map. */
   override def size: Int = forward.size
 
-  /**
-   *
-   * @return an iterator over tuples in this map.
-   */
-  def iterator: Iterator[(K, V)] = {
-    forward.iterator
+  /** Remove a key and its associated value from the map. */
+  override def subtractOne(elem: K): this.type = {
+    removeKey(elem)
+    this
+  }
+
+  /** Get a value associated with a given key. */
+  def valueFor(key: K): Option[V] = get(key)
+
+  /** The values in this map. */
+  override def values: Iterable[V] = reverse.keys
+
+  override protected def fromSpecific(coll: IterableOnce[(K, V)]): BiMap[K, V]    = BiMap.from(coll)
+  override protected def newSpecificBuilder: mutable.Builder[(K, V), BiMap[K, V]] = BiMap.newBuilder
+}
+
+/** The companion object for [[BiMap]]. */
+object BiMap {
+
+  /** Create a bi-directional map from a collection of key-value pairs. */
+  def apply[K, V](kvs: (K, V)*): BiMap[K, V] = from(kvs)
+
+  /** Create an empty bi-directional map. */
+  def empty[K, V]: BiMap[K, V] = new BiMap[K, V]
+
+  /** Create a bi-directional map from a collection of key-value pairs. */
+  def from[K, V](it: IterableOnce[(K, V)]): BiMap[K, V] = it match {
+    case it: Iterable[_] if it.isEmpty => empty[K, V]
+    case map: BiMap[K, V]              => map
+    case it                            =>
+      val map = new BiMap[K, V]
+      it.iterator.foreach { case (key, value) => map.add(key, value) }
+      map
+  }
+
+  /** Create a new growable builder for this bi-directional map. */
+  def newBuilder[K, V]: mutable.Builder[(K, V), BiMap[K, V]] = {
+    new MutableGrowableBuilder[(K, V), BiMap[K, V]](empty)
+  }
+
+  import scala.language.implicitConversions
+
+  /** Create a new factory for this bi-directional map. */
+  implicit def toFactory[K, V](self: this.type): Factory[(K, V), BiMap[K, V]] = {
+    new Factory[(K, V), BiMap[K, V]] {
+      def fromSpecific(it: IterableOnce[(K, V)]): BiMap[K, V] = self.from(it)
+      def newBuilder: mutable.Builder[(K, V), BiMap[K, V]]    = self.newBuilder[K, V]
+    }
   }
 }

--- a/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/PathUtil.scala
@@ -28,7 +28,7 @@ import java.nio.file.{Path, Paths}
 
 /** Provides utility methods for creating and manipulating Path objects and path-like Strings. */
 object PathUtil {
-  @deprecated("Use `IllegalCharacters`")
+  @deprecated("Use `IllegalCharacters`", since = "1.1.0")
   def illegalCharacters: String = IllegalCharacters
 
   val MaxFileNameSize: Int = 254

--- a/src/test/scala/com/fulcrumgenomics/commons/collection/BiMapTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/collection/BiMapTest.scala
@@ -25,9 +25,25 @@
 package com.fulcrumgenomics.commons.collection
 
 import com.fulcrumgenomics.commons.util.UnitSpec
+import org.scalatest.MustMatchers.convertToAnyMustWrapper
+import org.scalatest.OptionValues._
 
+/** Unit tests for [[BiMap]]. */
 class BiMapTest extends UnitSpec {
-  "BiMap.add" should "remove remove any key or value that already exists" in {
+
+  "BiMap.className" should "be 'BiMap'" in {
+    BiMap.empty.className shouldBe "BiMap"
+  }
+
+  "BiMap.addOne" should "add a key-value to the map" in {
+    val map = new BiMap[String, String]()
+    map.addOne("key1" -> "val1")
+    map.containsKey("key1") shouldBe true
+    map.containsValue("val1") shouldBe true
+    map should have size 1
+  }
+
+  "BiMap.add" should "add key-values to the map and remove any that already exists" in {
     val map = new BiMap[String, String]()
     map.add("key1", "val1")
     map.containsKey("key1") shouldBe true
@@ -46,6 +62,101 @@ class BiMapTest extends UnitSpec {
     map.containsValue("val1") shouldBe false
     map.containsValue("val2") shouldBe true
     map should have size 1
+  }
+
+  "BiMap.clear" should "clear the map" in {
+    val map = new BiMap[String, String]()
+    map.addOne("key1" -> "val1")
+    map.containsKey("key1") shouldBe true
+    map.containsValue("val1") shouldBe true
+    map should have size 1
+    map.clear()
+    map should have size 0
+  }
+
+  "BiMap.concat" should "concatenate additional key-value pairs while keeping the correct type" in {
+    val map = new BiMap[String, String]()
+    map.add("key1", "val1")
+    map.containsKey("key1") shouldBe true
+    map.containsValue("val1") shouldBe true
+    map should have size 1
+
+    val concatenated = map.concat(Seq("key2" -> "val2"))
+    map should have size 1
+    concatenated should have size 2
+    concatenated mustBe a[BiMap[_, _]]
+  }
+
+  "BiMap.containsKey" should "return true if it contains the key, false otherwise" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map.add(2, "2")
+    map.containsKey(1) shouldBe true
+    map.containsKey(2) shouldBe true
+    map.containsKey(3) shouldBe false
+  }
+
+  "BiMap.containsValue" should "return true if it contains the value, false otherwise" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map.add(2, "2")
+    map.containsValue("1") shouldBe true
+    map.containsValue("2") shouldBe true
+    map.containsValue("3") shouldBe false
+  }
+
+  "BiMap.empty(class)" should "return an empty BiMap" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map should have size 1
+    map.empty should have size 0
+  }
+
+  "BiMap.flatMap" should "map a function and flatten one level and return a BiMap" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    val actual   = map.flatMap { case (key, value) => Seq(key + 1 -> value) }
+    val expected = new BiMap[Int, String]()
+    expected.add(2, "1")
+    actual mustBe a[BiMap[_, _]]
+    actual shouldBe expected
+  }
+
+  "BiMap.get" should "either get a value for a key if it exists or return None" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map.get(1).value shouldBe "1"
+    map.get(2) shouldBe None
+  }
+
+  "BiMap.iterator" should "return the key-value pairs in an iterator" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map.iterator.toSeq shouldBe Seq(1 -> "1")
+  }
+
+  "BiMap.map" should "map a function" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    val actual   = map.map { case (key, value) => key + 1 -> value }
+    val expected = new BiMap[Int, String]()
+    expected.add(2, "1")
+    actual mustBe a[BiMap[_, _]]
+    actual shouldBe expected
+  }
+
+  "BiMap.keyFor" should "either get a key for a value if it exists or return None" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map.keyFor("1").value shouldBe 1
+    map.keyFor("2") shouldBe None
+  }
+
+  "BiMap.keys" should "return the keys of the map" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map.add(2, "2")
+    map.keys.toSeq should contain theSameElementsInOrderAs Seq(1, 2)
   }
 
   "BiMap.removeKey" should "remove the key and associated value from the map, and return true only if it exists" in {
@@ -74,27 +185,41 @@ class BiMapTest extends UnitSpec {
     map.isEmpty shouldBe true
   }
 
-  "BiMap.containsKey" should "return true if it contains the key, false otherwise" in {
+  "BiMap.size" should "return the size of the BiMap" in {
     val map = new BiMap[Int, String]()
+    map.isEmpty shouldBe true
     map.add(1, "1")
+    map.size shouldBe 1
     map.add(2, "2")
-    map.containsKey(1) shouldBe true
-    map.containsKey(2) shouldBe true
-    map.containsKey(3) shouldBe false
+    map.size shouldBe 2
   }
 
-  "BiMap.keys" should "return the keys" in {
+  "BiMap.subtractOne" should "remove the key and associated value from the map" in {
     val map = new BiMap[Int, String]()
     map.add(1, "1")
     map.add(2, "2")
-    map.keys shouldBe Set(1, 2).toIterable
+    map.size shouldBe 2
+    map.subtractOne(0)
+    map.size shouldBe 2
+    map.subtractOne(1)
+    map.size shouldBe 1
+    map.subtractOne(2)
+    map.isEmpty shouldBe true
   }
 
-  "BiMap.values" should "return the values" in {
+  "BiMap.valueFor" should "either get a value for a key if it exists or return None" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map.valueFor(1).value shouldBe "1"
+    map.valueFor(2) shouldBe None
+  }
+
+
+  "BiMap.values" should "return the values of the map" in {
     val map = new BiMap[Int, String]()
     map.add(1, "1")
     map.add(2, "2")
-    map.values shouldBe Set("1", "2").toIterable
+    map.values.toSeq should contain theSameElementsInOrderAs Seq("1", "2")
   }
 
   private case class CustomHashCode(code: Int) {
@@ -113,5 +238,33 @@ class BiMapTest extends UnitSpec {
     map.add(obj3, obj3.code) // collision!
 
     map.size shouldBe 2
+  }
+
+  "BiMap.apply" should "build a BiMap from a variadic set of key-value pairs" in {
+    val map = BiMap[Int, String](1 -> "1", 2 -> "2")
+    map should have size 2
+    map.toSeq should contain theSameElementsInOrderAs Seq(1 -> "1", 2 -> "2")
+  }
+
+  "BiMap.empty(companion object)" should "build an empty BiMap" in {
+    BiMap.empty shouldBe new BiMap()
+  }
+
+  "BiMap.from" should "build an empty BiMap from an empty collection" in {
+    BiMap.from(Seq.empty) shouldBe new BiMap()
+  }
+
+  it should "return a BiMap if a BiMap is itself the iterable" in {
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    BiMap.from(map) shouldBe map
+  }
+
+  it should "build a BiMap from a non-empty iterable of key-value pairs" in {
+    val seq = Seq(1 -> "1", 2 -> "2")
+    val map = new BiMap[Int, String]()
+    map.add(1, "1")
+    map.add(2, "2")
+    BiMap.from(seq) shouldBe map
   }
 }


### PR DESCRIPTION
I have a use case for `BiMap` and need it to act more like a real Scala collection.

This compiles on 2.13.

The class builder is compatible with both 2.12 and 2.13.

However, I don't know how to make backward compat for these Scala 2.13 traits:

- `MapOps`
- `StrictOptimizedMapOps`
- `StrictOptimizedIterableOps`

In the meantime, I can compile this directly into my own 2.13 project. Feel free to take this PR or close it. It might be nice to have as an upgrade if you ever drop 2.12.