### PR TITLE
Fix AsyncIterator race condition when first element in source raises

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/async/AsyncIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/async/AsyncIterator.scala
@@ -25,6 +25,8 @@
 
 package com.fulcrumgenomics.commons.async
 
+import com.fulcrumgenomics.commons.CommonsDef.yieldAndThen
+
 import java.util.concurrent.{ArrayBlockingQueue, BlockingQueue, LinkedBlockingDeque, TimeUnit}
 
 object AsyncIterator {
@@ -72,8 +74,8 @@ class AsyncIterator[T](private val source: Iterator[T], bufferSize: Option[Int] 
       }
     }
 
-    // Did we get an item from the buffer?
-    buffer.nonEmpty
+    // Did we get an item from the buffer? After testing the buffer, perform an exception check and raise if needed.
+    yieldAndThen(buffer.nonEmpty)(checkAndRaise())
   }
 
   /** Gets the next item. */

--- a/src/main/scala/com/fulcrumgenomics/commons/async/AsyncIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/async/AsyncIterator.scala
@@ -68,7 +68,7 @@ class AsyncIterator[T](private val source: Iterator[T], bufferSize: Option[Int] 
 
     // Get the next item, or wait until the underlying thread is done and there are no more items in the queue
     while (buffer.isEmpty && !(this.done && this.queue.isEmpty)) {
-      checkAndRaise() // check if hte underlying thread raised an exception
+      checkAndRaise() // check if the underlying thread raised an exception
       tryAndModifyInterruptedException("Interrupted waiting on taking from the queue.") {
         buffer = Option(this.queue.poll(50, TimeUnit.MILLISECONDS))
       }
@@ -85,6 +85,8 @@ class AsyncIterator[T](private val source: Iterator[T], bufferSize: Option[Int] 
       case None => throw new NoSuchElementException("Calling next() when hasNext() is false.")
       case Some(item) =>
         this.buffer = None
+        // Now that the buffer is emptied, make a call to hasNext() to see if there are any more elements or exceptions.
+        if (!hasNext()) checkAndRaise()
         item
     }
   }

--- a/src/main/scala/com/fulcrumgenomics/commons/async/AsyncIterator.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/async/AsyncIterator.scala
@@ -66,7 +66,7 @@ class AsyncIterator[T](private val source: Iterator[T], bufferSize: Option[Int] 
 
     // Get the next item, or wait until the underlying thread is done and there are no more items in the queue
     while (buffer.isEmpty && !(this.done && this.queue.isEmpty)) {
-      checkAndRaise() // check if hte underlying thread raised an exception
+      checkAndRaise() // check if the underlying thread raised an exception
       tryAndModifyInterruptedException("Interrupted waiting on taking from the queue.") {
         buffer = Option(this.queue.poll(50, TimeUnit.MILLISECONDS))
       }

--- a/src/test/scala/com/fulcrumgenomics/commons/async/AsyncIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/async/AsyncIteratorTest.scala
@@ -45,6 +45,14 @@ class AsyncIteratorTest extends UnitSpec with OptionValues {
     }
   }
 
+  Seq(1, 2, 3).zip(Seq("first", "middle", "last")).foreach { case (exceptional, text) =>
+    it should s"raise an exception on an exception-raising $text element within the source iterator" in {
+      def raise(num: Int): Int = if (num == exceptional) throw new IllegalArgumentException("Exceptional!") else num
+      val source = Seq(1, 2, 3).iterator.map(raise)
+      an[IllegalArgumentException] shouldBe thrownBy { new AsyncIterator(source = source).start().toSeq }
+    }
+  }
+
   "AsyncIterator.apply" should "start a daemon thread via apply" in {
     val iter = AsyncIterator[String](Iterator("hello world"))
     iter.hasNext() shouldBe true

--- a/src/test/scala/com/fulcrumgenomics/commons/async/AsyncIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/async/AsyncIteratorTest.scala
@@ -45,12 +45,10 @@ class AsyncIteratorTest extends UnitSpec with OptionValues {
     }
   }
 
-  Seq(1, 2, 3).zip(Seq("first", "middle", "last")).foreach { case (exceptional, text) =>
-    it should s"raise an exception on an exception-raising $text element within the source iterator" in {
-      def raise(num: Int): Int = if (num == exceptional) throw new IllegalArgumentException("Exceptional!") else num
-      val source = Seq(1, 2, 3).iterator.map(raise)
-      an[IllegalArgumentException] shouldBe thrownBy { new AsyncIterator(source = source).start().toSeq }
-    }
+  it should s"correctly propagate an exception that originates from within the source iterator" in {
+    def raise(num: Int): Int = throw new IllegalArgumentException(num.toString)
+    val source = Range(1, 10).iterator.map(raise)
+    an[IllegalArgumentException] shouldBe thrownBy { new AsyncIterator(source = source).start().toSeq }
   }
 
   "AsyncIterator.apply" should "start a daemon thread via apply" in {

--- a/src/test/scala/com/fulcrumgenomics/commons/async/AsyncIteratorTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/async/AsyncIteratorTest.scala
@@ -46,9 +46,15 @@ class AsyncIteratorTest extends UnitSpec with OptionValues {
   }
 
   it should s"correctly propagate an exception that originates from within the source iterator" in {
+    // Issue: https://github.com/fulcrumgenomics/commons/pull/74
+    var exceptionNotRaisedInTime = false
     def raise(num: Int): Int = throw new IllegalArgumentException(num.toString)
-    val source = Range(1, 10).iterator.map(raise)
+    val source = Range(1, 10000).iterator.map { num =>
+      if (num > 1) exceptionNotRaisedInTime = true // We do this because we can't successfully raise in this context.
+      raise(num)
+    }
     an[IllegalArgumentException] shouldBe thrownBy { new AsyncIterator(source = source).start().toSeq }
+    withClue("Failed because the illegal argument exception was not caught in time:") { exceptionNotRaisedInTime shouldBe false }
   }
 
   "AsyncIterator.apply" should "start a daemon thread via apply" in {


### PR DESCRIPTION
This PR fixes a race condition with the exception-raising mechanics of `AsyncIterator`.

The bug occurs when the head (or the first few) elements of the source iterator raise exceptions. The prior mechanics of `AsyncIterator` might run the check-and-raise call in the `hasNext()` block _**before**_ any of the first elements are actually computed. This means that exceptions can be swallowed and your iterator will be silently truncated to 0-length.

A quick example of how the race condition will create missing data:

```scala
 def raiseOnTen(num: Int): Int = if (num == 10) throw new IllegalArgumentException else num
 new AsyncIterator(Seq(10, 11, 12, 13).iterator.map(raiseOnTen)).start().toSeq == Seq.empty
```