### PR TITLE
feat: expose the header in Row

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -78,6 +78,9 @@ class Row private[util] (private val headerIndices: Map[String,Int], private val
       case (None, true)   => None
       case (None, false)  => throw new NoSuchElementException(column)
     }
+
+  /** Gets the header key (column name) for this row */
+  def header: Iterable[String] = this.headerIndices.keys
 }
 
 

--- a/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/util/DelimitedDataParser.scala
@@ -79,7 +79,7 @@ class Row private[util] (private val headerIndices: Map[String,Int], private val
       case (None, false)  => throw new NoSuchElementException(column)
     }
 
-  /** Gets the header key (column name) for this row */
+  /** Gets the header keys (column names) for this row */
   def header: Iterable[String] = this.headerIndices.keys
 }
 

--- a/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
@@ -218,4 +218,10 @@ class DelimitedDataParserTest extends UnitSpec {
     row.get[String]("c", allowMissingColumn=true) shouldBe None
   }
 
+  "DelimitedDataParser.header" should "return the column header" in {
+    val parser = csv(Seq("a,b,c", "1,2,"))
+    val row = parser.next()
+    row.header.toIndexedSeq should contain theSameElementsInOrderAs Seq("a", "b", "c")
+  }
+
 }

--- a/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
+++ b/src/test/scala/com/fulcrumgenomics/commons/util/DelimitedDataParserTest.scala
@@ -218,7 +218,7 @@ class DelimitedDataParserTest extends UnitSpec {
     row.get[String]("c", allowMissingColumn=true) shouldBe None
   }
 
-  "DelimitedDataParser.header" should "return the column header" in {
+  "Row.header" should "return the header for all columns" in {
     val parser = csv(Seq("a,b,c", "1,2,"))
     val row = parser.next()
     row.header.toIndexedSeq should contain theSameElementsInOrderAs Seq("a", "b", "c")


### PR DESCRIPTION
Fixes #87 

This is useful when `Row` is being passed around.  I kept it as `Iterable` in a `def` so that we don't consume more memory.