### PR TITLE
Ensure file toRealPath() does not raise for file descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 target
+.java-version
+**/*.iml

--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -31,7 +31,7 @@ import com.fulcrumgenomics.commons.CommonsDef._
 
 import scala.collection.compat._
 import scala.io.Source
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 /**
 * Singleton object to provide access to Io utility methods.


### PR DESCRIPTION
The implementation of [`.toRealPath()`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#toRealPath-java.nio.file.LinkOption...-) is platform-dependent and I discovered will raise an exception if called on a file descriptor on Unix platforms (like Linux) but not on Mac. This exception is not caught and halts the program. For example:

```console
Exception in thread "main" java.nio.file.NoSuchFileException: /dev/fd/63
    at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
    at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
    at java.base/sun.nio.fs.UnixPath.toRealPath(UnixPath.java:886)
    at com.fulcrumgenomics.commons.io.IoUtil.toInputStream(Io.scala:65)
    at com.fulcrumgenomics.commons.io.IoUtil.toInputStream$(Io.scala:58)
    at com.fulcrumgenomics.util.Io.toInputStream(Io.scala:37)
    at com.fulcrumgenomics.commons.io.IoUtil.toSource(Io.scala:96)
    at com.fulcrumgenomics.commons.io.IoUtil.toSource$(Io.scala:95)
    at com.fulcrumgenomics.util.Io.toSource(Io.scala:37)
    at com.fulcrumgenomics.commons.io.IoUtil.readLines(Io.scala:213)
    at com.fulcrumgenomics.commons.io.IoUtil.readLines$(Io.scala:213)
    at com.fulcrumgenomics.util.Io.readLines(Io.scala:37)
```

When trying to read an input file with syntax like:

```bash
tool --input <( ... )
```

To solve this issue, we classify all paths that raise an exception when `.toRealPath()` is called as special files and open them for reading using a non-buffered input stream. I also confirmed that buffered input streaming does not work on named pipes and also fails on file descriptors too. I updated the line comments to reflect that.

I tested this on both Mac and Linux platforms and this PR fixes my issues.