### PR TITLE
Ensure sbt is installed prior to GHA publish

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -92,6 +92,13 @@ jobs:
           fetch-depth: 0
           # To work with the `pull_request` or any other non-`push` even with git-auto-commit
           ref: ${{ github.head_ref }}
+      - name: Setup cache
+        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+      - name: setup Scala
+        uses: coursier/setup-action@039f736548afa5411c1382f40a5bd9c2d30e0383 # v1.3.9
+        with:
+          apps: scala:2.13.14 scalac:2.13.14 scaladoc:2.13.14 sbt:1.11.2
+          jvm: "temurin:1.8.0-442"
       - name: Setup GPG
         shell: bash -l {0}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 target
 .java-version
 **/*.iml
+.metals/
+.vscode/


### PR DESCRIPTION
The release job is broken on the `main` branch.

It appears we need to install sbt ahead of time.

I don't have a good way of testing this PR, though...