### PR TITLE
Ensure Io.assertReadable works on file descriptors too

### DIFF
--- a/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
+++ b/src/main/scala/com/fulcrumgenomics/commons/io/Io.scala
@@ -114,7 +114,8 @@ trait IoUtil {
     if (path == null)                throw new IllegalArgumentException("Cannot check readability of null path.")
     assert(!Files.notExists(path),   "Cannot read non-existent path: " + path)
     assert(!Files.isDirectory(path), "Cannot read path because it is a directory: " + path)
-    assert(Files.isReadable(path),   "Path exists but is not readable: " + path)
+    val isSpecialFd = Option(path.toString).exists(path => path.startsWith("/dev/fd") || path.startsWith("/proc/self/fd/"))
+    if (!isSpecialFd) { assert(Files.isReadable(path), "Path exists but is not readable: " + path) }
   }
 
   /** Asserts that the Paths represent directories that can be listed. */


### PR DESCRIPTION
The function `Files.isReadable` does not work on file descriptors, unfortunately. So for any path that looks like a file descriptor, we should skip the `Files.isReadable` check.  I couldn't think or find of a better way of testing readability of a file descriptor without causing a side effect (such as by trying to open it).
