### PR TITLE
fix(ci): prevent release job cancellation and add sonaRelease step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,64 +1,24 @@
-name: unit tests
+name: release
 
 on:
   push:
-  pull_request:
-  workflow_call:
-    secrets:
-      CODECOV_TOKEN:
-        required: true
-      SONATYPE_USER:
-        required: false
-      SONATYPE_PASS:
-        required: false
+    tags: 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    concurrency:
-      group: test-${{ github.workflow }}-${{ github.ref }}-${{ matrix.jvm }}
-      cancel-in-progress: true
-    strategy:
-      matrix:
-        jvm: ["temurin:1.8.0-442", "temurin:1.11.0.27", "temurin:1.17.0.15", "temurin:1.21.0.7", "temurin:1.22.0.2"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Setup cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
-      - name: setup Scala
-        uses: coursier/setup-action@039f736548afa5411c1382f40a5bd9c2d30e0383 # v1.3.9
-        with:
-          apps: scala:2.13.14 scalac:2.13.14 scaladoc:2.13.14 sbt:1.11.2
-          jvm: ${{ matrix.jvm }}
-      - name: Unit Tests
-        run: |
-          set -e
-          sbt clean coverage test
-          sbt coverageReport coverageAggregate
-      - name: Code Coverage
-        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d  # v5.4.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittests # optional
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
-                # while the "docs" job below tests building the online docs, this is added here
-      # to fail-fast when docs are not correctly written.
-      - name: Ensure docs will compile (fast-fail)
-        run: |
-          set -e
-          sbt doc
+  tests:
+    name: tests
+    uses: "./.github/workflows/unittests.yaml"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   release:
-    if: ${{ github.repository == 'fulcrumgenomics/commons' && github.ref == 'refs/heads/main' && github.event_name != 'workflow_call' }}
-    needs: test
+    name: Release to Maven Central
+    needs: tests
     runs-on: ubuntu-latest
+    environment: github-actions
     concurrency:
       group: release-${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: false
-    environment: github-actions
     env:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
       SONATYPE_PASS: ${{ secrets.SONATYPE_PASS }}
@@ -92,8 +52,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          # To work with the `pull_request` or any other non-`push` even with git-auto-commit
-          ref: ${{ github.head_ref }}
       - name: Setup cache
         uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
       - name: setup Scala
@@ -109,3 +67,7 @@ jobs:
         shell: bash -l {0}
         run: |
           sbt +publishSigned
+      - name: Release to Sonatype
+        shell: bash -l {0}
+        run: |
+          sbt sonaRelease

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -12,13 +12,12 @@ on:
       SONATYPE_PASS:
         required: false
 
-concurrency:
-  group: unittest-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: test-${{ github.workflow }}-${{ github.ref }}-${{ matrix.jvm }}
+      cancel-in-progress: true
     strategy:
       matrix:
         jvm: ["temurin:1.8.0-442", "temurin:1.11.0.27", "temurin:1.17.0.15", "temurin:1.21.0.7", "temurin:1.22.0.2"]
@@ -56,6 +55,9 @@ jobs:
     if: ${{ github.repository == 'fulcrumgenomics/commons' && github.ref == 'refs/heads/main' && github.event_name != 'workflow_call' }}
     needs: test
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
     environment: github-actions
     env:
       SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
@@ -106,4 +108,4 @@ jobs:
       - name: Build and sign artifacts
         shell: bash -l {0}
         run: |
-          sbt +publishSigned
+          sbt +publishSigned sonaRelease


### PR DESCRIPTION
## Summary
- Move concurrency settings from workflow level to job level
- Test jobs use `cancel-in-progress: true` with matrix variable in group name
- Release job uses `cancel-in-progress: false` to ensure releases complete
- Add separate `release.yaml` workflow for publishing to Maven Central on version tags
- Remove `sonaRelease` from `unittests.yaml` (SNAPSHOTs don't support it)

## Changes
- **unittests.yaml**: Publishes SNAPSHOTs on main branch pushes (`publishSigned` only)
- **release.yaml** (new): Publishes releases on version tags (`publishSigned` + `sonaRelease`)

## Test plan
- [ ] Verify workflow syntax is valid by checking GitHub Actions tab
- [ ] Monitor next SNAPSHOT publish to confirm it succeeds without sonaRelease
- [ ] Monitor next release to confirm artifacts are uploaded to Maven Central via release.yaml